### PR TITLE
Fix page width on docs pages with responsive container

### DIFF
--- a/custom_template/layout/_master.tmpl
+++ b/custom_template/layout/_master.tmpl
@@ -23,7 +23,7 @@
         {{>partials/searchResults}}
       </div>
         {{/_enableSearch}}
-      <div role="main" class="container body-content hide-when-search">
+      <div role="main" class="container-fluid body-content hide-when-search">
         {{^_disableToc}}
         {{>partials/toc}}
         <div class="article row grid-right">
@@ -35,18 +35,26 @@
           <div class="col-md-12">
             {{/_disableAffix}}
             {{^_disableAffix}}
-          <div class="col-md-10">
-            {{/_disableAffix}}
-            <article class="content wrap" id="_content" data-uid="{{uid}}">
-              {{!body}}
-              {{#_showGrid}}
-              {{>partials/products}}
-              {{/_showGrid}}
-            </article>
+          <div class="container-fluid">
+            <div class="row">
+              <div class="col-md-10">
+                {{/_disableAffix}}
+                <article class="content wrap" id="_content" data-uid="{{uid}}">
+                  {{#_showGrid}}<div class="col-md-offset-2">{{/_showGrid}}{{!body}}{{#_showGrid}}</div>{{/_showGrid}}
+                  <div class="row">
+                    <div class="col-md-offset-2 col-md-10">
+                      {{#_showGrid}}
+                      {{>partials/products}}
+                      {{/_showGrid}}
+                    </div>
+                  </div>
+                </article>
+              </div>
+              {{^_disableAffix}}
+              {{>partials/affix}}
+              {{/_disableAffix}}
+            </div>
           </div>
-          {{^_disableAffix}}
-          {{>partials/affix}}
-          {{/_disableAffix}}
         </div>
       </div>
       {{^_disableFooter}}

--- a/custom_template/partials/products.tmpl.partial
+++ b/custom_template/partials/products.tmpl.partial
@@ -5,7 +5,7 @@
 </style>
 
 <products>
-  <div class="container">
+  <div class="row">
     <div class="product_grid-1">
       <a href="http://docs.ukcloud.com/articles/vmware/vmw-gs.html">
         <div class="product_grid-2 child-1 border-main">VMware</div>


### PR DESCRIPTION
Added a new row for the grid of products, moving the 'Improve this Doc' out of the way. 
Offset both the grid and title on index to balance the page. 
Content now spans the full width of the window