### PR TITLE
Semps 994 responsive fix

### DIFF
--- a/custom_template/partials/products.tmpl.partial
+++ b/custom_template/partials/products.tmpl.partial
@@ -7,19 +7,19 @@
 <products>
   <div class="container">
     <div class="product_grid-1">
-      <a href="http://docs.ukcloud.com/articles/vmware/vmw-gs.html">
+      <a href="/articles/vmware/vmw-gs.html">
         <div class="product_grid-2 child-1 border-main">VMware</div>
       </a>
-      <a href="http://docs.ukcloud.com/articles/openstack/ostack-gs.html">
+      <a href="/articles/openstack/ostack-gs.html">
         <div class="product_grid-2 child-2 border-main">OpenStack</div>
       </a>
-      <a href="http://docs.ukcloud.com/articles/azure/azs-gs.html">
+      <a href="/articles/azure/azs-gs.html">
         <div class="product_grid-2 child-3 border-main">Azure</div>
       </a>
-      <a href="http://docs.ukcloud.com/articles/oracle/orcl-gs.html">
+      <a href="/articles/oracle/orcl-gs.html">
         <div class="product_grid-2 child-4 border-main">Oracle</div>
       </a>
-      <a href="http://docs.ukcloud.com/articles/openshift/oshift-gs.html">
+      <a href="/articles/openshift/oshift-gs.html">
         <div class="product_grid-2 child-5 border-main border-right">OpenShift</div>
       </a>
       <a href="">

--- a/custom_template/styles/docfx.css
+++ b/custom_template/styles/docfx.css
@@ -743,7 +743,7 @@ footer {
     display: inline-block;
   }
 }
-@media only screen and (max-width: 768px) {
+@media only screen and (max-width: 767px) {
   #mobile-indicator {
     display: block;
   }
@@ -787,7 +787,7 @@ footer {
   .toc .level1 > li {
     display: block;
   }
-  
+
   .toc .level1 > li:after {
     display: none;
   }


### PR DESCRIPTION
At a width of 768px, the table of contents showed outside it's dropdown and overlaid the page. This no longer happens