### PR TITLE
Clarify Incident Priority

### DIFF
--- a/articles/portal/ptl-how-raise-escalate-service-request.md
+++ b/articles/portal/ptl-how-raise-escalate-service-request.md
@@ -86,7 +86,7 @@ Ticket priority | Initial response target | Resolution target
 **Priority 1** | **Priority 2**
 A significant outage or disruption to multiple users or locations is in progress</br></br>Compromise, loss or unavailability of data has occurred | Service is available but degraded or restricted for multiple users or locations</br></br>Suspected or potential compromise, loss or unavailability of data
 **Priority 3** | **Priority 4**
-A failure or degradation of redundant or non-critical components of service has occurred</br></br>Failure of a shared service, where alternative services remain available, or service disruption for single users | Documented housekeeping activities</br></br>Administration related requirements or an uncategorised incident
+A failure or degradation of redundant or non-critical components of service has occurred for a single user</br></br>Failure of a shared service, where alternative services remain available, or service disruption for single users | Documented housekeeping activities</br></br>Administration related requirements or an uncategorised incident
 
 ## Viewing tickets and service updates
 


### PR DESCRIPTION
Just to clarify the priority 3 in comparison to 2, as the first line is similar. Also, because in the portal list of incident priorities, there is only one option for priority 3 which is "isolated to a single user". Therefore I have added the words: "for a single user" so as to clarify to customers that it is a priority for a single user and priority 2 is for multiple users