### PR TITLE
OpenShift update links to 3.9

### DIFF
--- a/articles/openshift/oshift-faq.md
+++ b/articles/openshift/oshift-faq.md
@@ -129,7 +129,7 @@ In order to add new users, you will need to raise a [Service Request](https://po
 
 ### What monitoring of the services is provided by default in a trial?
 
-By default, no specific monitoring service is integrated. However, we recommend external monitoring services such as Datadog or Coscale for production-grade OpenShift hosted applications. Alternatively, a simple monitoring solution can be implemented by the customer themselves - an example is outlined here: [How to monitor your OpenShift cluster](oshift-how-monitor-cluster.md)
+By default, no specific monitoring service is integrated. However, we recommend external monitoring services such as Datadog or Coscale for production-grade OpenShift hosted applications. Alternatively, you can implement your own simple monitoring solution as described in [How to monitor your OpenShift cluster](oshift-how-monitor-cluster.md).
 
 ### What monitoring of the services is provided on a billable service?
 

--- a/articles/openshift/oshift-faq.md
+++ b/articles/openshift/oshift-faq.md
@@ -129,7 +129,7 @@ In order to add new users, you will need to raise a [Service Request](https://po
 
 ### What monitoring of the services is provided by default in a trial?
 
-By default, a minimal Zabbix infrastructure gets deployed to enable customer monitoring of the nodes and other services. However, we recommend external monitoring services such as Datadog or Coscale for production-grade OpenShift hosted applications.
+By default, no specific monitoring service is integrated. However, we recommend external monitoring services such as Datadog or Coscale for production-grade OpenShift hosted applications. Alternatively, a simple monitoring solution can be implemented by the customer themselves - an example is outlined here: [How to monitor your OpenShift cluster](oshift-how-monitor-cluster.md)
 
 ### What monitoring of the services is provided on a billable service?
 

--- a/articles/openshift/oshift-gs.md
+++ b/articles/openshift/oshift-gs.md
@@ -58,7 +58,7 @@ containers.
 
 ![OpenShift pods and containers](images/oshift-pods-containers.png)
 
-**OpenShift documentation:** [*Architecture*](https://docs.openshift.com/container-platform/3.5/architecture/index.html) and [*Container Security Guide*](https://docs.openshift.com/container-platform/3.5/security/index.html)
+**OpenShift documentation:** [*Architecture*](https://docs.openshift.com/container-platform/3.9/architecture/index.html) and [*Container Security Guide*](https://docs.openshift.com/container-platform/3.9/security/index.html)
 
 ## Before you begin
 
@@ -68,7 +68,7 @@ As part of your onboarding, UKCloud will provide you with a URL and credentials 
 
 In addition, we recommend the installation of the OpenShift CLI on your device.
 
-**OpenShift documentation:** [*Get Started with the CLI*](https://docs.openshift.com/container-platform/3.5/cli_reference/get_started_cli.html)
+**OpenShift documentation:** [*Get Started with the CLI*](https://docs.openshift.com/container-platform/3.9/cli_reference/get_started_cli.html)
 
 ## Initial environment
 
@@ -80,14 +80,14 @@ You can expand the Starter Pack in increments of 16GiB, to a maximum OpenShift e
 
 The OpenShift Container Platform web console is a user interface accessible from a web browser. Developers can use the web console to visualize, browse, and manage the contents of projects.
 
-**OpenShift documentation:** [*Web Console Walkthrough*](https://docs.openshift.com/container-platform/3.5/getting_started/developers_console.html)
+**OpenShift documentation:** [*Web Console Walkthrough*](https://docs.openshift.com/container-platform/3.9/getting_started/developers_console.html)
 
 ## Using the command-line interface
 
 With the OpenShift Container Platform command line interface (CLI), you can create applications and manage OpenShift Container Platform projects from a terminal.
 
-**OpenShift documentation:** [*Basic Walkthrough Using the CLI*](https://docs.openshift.com/container-platform/3.5/getting_started/developers_cli.html)
-and [*CLI Reference*](https://docs.openshift.com/container-platform/3.5/cli_reference/index.html)
+**OpenShift documentation:** [*Basic Walkthrough Using the CLI*](https://docs.openshift.com/container-platform/3.9/getting_started/developers_cli.html)
+and [*CLI Reference*](https://docs.openshift.com/container-platform/3.9/cli_reference/index.html)
 
 ## Using the API
 
@@ -95,23 +95,23 @@ The OpenShift Container Platform distribution of Kubernetes includes the Kuberne
 
 These REST APIs can be used to manage end-user applications, the cluster, and the users of the cluster.
 
-**OpenShift documentation:** [*REST API Reference*](https://docs.openshift.com/container-platform/3.5/rest_api/index.html)
+**OpenShift documentation:** [*REST API Reference*](https://docs.openshift.com/container-platform/3.9/rest_api/index.html)
 
 ## Developing and deploying applications
 
 OpenShift Container Platform is designed for building and deploying applications. You can begin your application's development from scratch using OpenShift Container Platform directly or develop locally then use OpenShift Container Platform to deploy your fully developed application.
 
-**OpenShift documentation:** [*Developer Guide*](https://docs.openshift.com/container-platform/3.5/dev_guide/index.html)
+**OpenShift documentation:** [*Developer Guide*](https://docs.openshift.com/container-platform/3.9/dev_guide/index.html)
 
 ## Creating and using images
 
 Containers in OpenShift Container Platform are based on Docker-formatted container images. An image is a binary that includes all the requirements for running a single container, as well as metadata describing its needs and capabilities. Containers only have access to resources defined in the image unless you give the container additional access when creating it.
 
-**OpenShift documentation:** [*Creating images*](https://docs.openshift.com/container-platform/3.5/creating_images/index.html) and [*Using images*](https://docs.openshift.com/container-platform/3.5/using_images/index.html)
+**OpenShift documentation:** [*Creating images*](https://docs.openshift.com/container-platform/3.9/creating_images/index.html) and [*Using images*](https://docs.openshift.com/container-platform/3.9/using_images/index.html)
 
 ## Next steps
 
-In this Getting Started Guide, you've learned the basics about UKCloud for OpenShift. For more information, see the OpenShift documentation at [*OpenShift Container Platform 3.5 Documentation*](https://docs.openshift.com/container-platform/3.5/welcome/index.html)
+In this Getting Started Guide, you've learned the basics about UKCloud for OpenShift. For more information, see the OpenShift documentation at [*OpenShift Container Platform 3.9 Documentation*](https://docs.openshift.com/container-platform/3.9/welcome/index.html)
 
 ## Glossary
 

--- a/articles/openshift/oshift-how-obtain-usage-metrics.md
+++ b/articles/openshift/oshift-how-obtain-usage-metrics.md
@@ -43,7 +43,7 @@ The sections in this guide, show you how to obtain various statistics about the 
 
 ### Intended audience
 
-To complete the steps in this guide you must have access to and a working knowledge of `oc`, the OpenStack command-line client (CLI). For more information, see OpenShift's [*Get Started with the CLI*](https://docs.openshift.com/container-platform/3.7/cli_reference/get_started_cli.html).
+To complete the steps in this guide you must have access to and a working knowledge of `oc`, the OpenStack command-line client (CLI). For more information, see OpenShift's [*Get Started with the CLI*](https://docs.openshift.com/container-platform/3.9/cli_reference/get_started_cli.html).
 
 ## Identifying capacity statistics
 
@@ -103,7 +103,7 @@ Object storage is used only for the OpenShift registry, therefore, you can calcu
 
 ## Other monitoring options
 
-You can find a simple example of a custom monitoring application, using the REST API described above, in [*How to monitor your OpenShift cluster*](oshift-how-monitor-cluster.md) and as a [UKCloud blog post](https://ukcloud.com/news-resources/news/blog/simple-openshift-monitoring).
+You can find a simple example of a custom monitoring application, using the REST API described above, in [*How to monitor your OpenShift cluster*](oshift-how-monitor-cluster.md) and as a [UKCloud blog post](https://ukcloud.com/hub/news/simple-openshift-monitoring/).
 
 You can also perform monitoring using Hawkular, which is built into the product. You can access Hawkular from the browser-based console at:
 


### PR DESCRIPTION
Small update to make the Red Hat link to point to 3.9 versions.

- Updated Red Hat doc links to 3.9 version
- Updated a blog post link to work on new UKCloud website
- Removed reference to Zabbix and added link to Simple Monitor doc.