### PR TITLE
openshift-route-ip-whitelisting

### DIFF
--- a/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
+++ b/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
@@ -55,7 +55,7 @@ You can even use a mix of IP addresses and a network CIDR:
 
     oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10 180.5.61.153 192.168.1.0/24 10.0.0.0/8
 
-To delete the IP's from the annotation, you can run the command:
+To delete the IPs from the annotation, you can run the command:
     
     oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=''
 

--- a/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
+++ b/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
@@ -63,6 +63,9 @@ To delete the IPs from the annotation, you can run the command:
 
 For further infomation, see the following: [Openshift Documentation](https://docs.openshift.com/container-platform/3.9/architecture/networking/routes.html)
 
+> [!IMPORTANT]
+> This functionality is available in OpenShift 3.10 by default. For all previous versions customers need to raise a request with UK Cloud to have this functionality turned on. 
+
 
 ## Feedback
 

--- a/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
+++ b/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
@@ -1,6 +1,6 @@
 ---
-title: How to restrict access to a route in OpenShift by the source public IP address
-description: Restrict access to OpenShift routes by the source public IP address
+title: How to restrict access to OpenShift routes by IP address
+description: Restrict access to OpenShift routes by IP address
 services: openshift
 author: Mudasar Hussain
 toc_rootlink: How To
@@ -8,29 +8,29 @@ toc_sub1:
 toc_sub2:
 toc_sub3:
 toc_sub4:
-toc_title: Restrict access to OpenShift routes by the source public IP address
-toc_fullpath: How To/restricting-access-to-openshift-routes-by-ip.md
-toc_mdlink: oshift-how-restrict-access-to-openshift-routes-by-ip.md
+toc_title: Restrict access to OpenShift routes by IP address
+toc_fullpath: How To/restrict-access-to-openshift-routes-by-ip-address.md
+toc_mdlink: oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
 ---
 
 # How to only allow trusted IP's to be able to access routes in Openshift
 
 ## Overview
 
-This knowledge centre article explains how OpenShift developers can restrict access to the routes they create to their deployed services in OpenShift by IP address. This can be done to increase the security of a route by only allowing trusted IP's to access the OpenShift route.
+This knowledge centre article explains how OpenShift developers can restrict access to the routes they create to their deployed services in OpenShift by IP address. Restricting access in this way increases the security of a route by allowing only trusted IPs to access the OpenShift route.
 
 ### Intended audience
 
-OpenShift developers who have already created and deployed services into OpenShift and also created routes for those services and exposed those routes. This article helps those users to further secure access to those exposed routes by restricting access to those exposed routes by only allowing trusted IP's to be able to access those routes.
+OpenShift developers who have created and deployed services into OpenShift, and created and exposed routes for those services. This article describes how to further secure access to those exposed routes by allowing only trusted IPs to access them.
 
 ## Restricting access to a route
 
 After creating and exposing a route in OpenShift in the usual manner, you can then add an annotation to the route specifying the IP address(es) that you would like to whitelist.
   
 > [!IMPORTANT]
-> Whitelisting a IP address automaticly blacklists everything else.
+> Whitelisting a IP address automatically blacklists everything else.
   
-  You apply the annotation to a route in the following manner:
+You apply the annotation to a route in the following manner:
   
     oc annotate route <route_name> haproxy.router.openshift.io/ip_whitelist=<ip_address>
 
@@ -43,11 +43,11 @@ To allow a single IP address through to the route, use the following:
   
     oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10
 
-To allow a several IP addresses through to the route, separate each IP with a space:
+To allow several IP addresses through to the route, separate each IP with a space:
 
     oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10 192.168.1.11 192.168.1.12
 
-To allow a network CIDR through to the route, decrlare the network CIDR as so:
+To allow a network CIDR through to the route, declare the network CIDR as so:
 
     oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10/24
 

--- a/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
+++ b/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
@@ -55,6 +55,10 @@ You can even use a mix of IP addresses and a network CIDR:
 
     oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10 180.5.61.153 192.168.1.0/24 10.0.0.0/8
 
+To delete the IP's from the annotation, you can run the command:
+    
+    oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=''
+
 ## More information
 
 For further infomation, see the following: [Openshift Documentation](https://docs.openshift.com/container-platform/3.9/architecture/networking/routes.html)

--- a/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
+++ b/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
@@ -64,7 +64,7 @@ To delete the IPs from the annotation, you can run the command:
 For further infomation, see the following: [Openshift Documentation](https://docs.openshift.com/container-platform/3.9/architecture/networking/routes.html)
 
 > [!IMPORTANT]
-> This functionality is available in OpenShift 3.10 by default. For all previous versions customers need to raise a request with UK Cloud to have this functionality turned on. 
+> This functionality is available by default in UKCloud OpenShift deployments of version 3.10 or newer. For all previous versions customers need to raise a request with UKCloud to have this functionality enabled. 
 
 
 ## Feedback

--- a/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
+++ b/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip-address.md
@@ -41,23 +41,23 @@ You apply the annotation to a route in the following manner:
 
 To allow a single IP address through to the route, use the following:
   
-    oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10
+    oc annotate route <route_name> haproxy.router.openshift.io/ip_whitelist=192.168.1.10
 
 To allow several IP addresses through to the route, separate each IP with a space:
 
-    oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10 192.168.1.11 192.168.1.12
+    oc annotate route <route_name> haproxy.router.openshift.io/ip_whitelist=192.168.1.10 192.168.1.11 192.168.1.12
 
 To allow a network CIDR through to the route, declare the network CIDR as so:
 
-    oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10/24
+    oc annotate route <route_name> haproxy.router.openshift.io/ip_whitelist=192.168.1.10/24
 
 You can even use a mix of IP addresses and a network CIDR:
 
-    oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10 180.5.61.153 192.168.1.0/24 10.0.0.0/8
+    oc annotate route <route_name> haproxy.router.openshift.io/ip_whitelist=192.168.1.10 180.5.61.153 192.168.1.0/24 10.0.0.0/8
 
 To delete the IPs from the annotation, you can run the command:
     
-    oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=''
+    oc annotate route <route_name> haproxy.router.openshift.io/ip_whitelist-
 
 ## More information
 

--- a/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip.md
+++ b/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip.md
@@ -1,0 +1,57 @@
+---
+title: UKCloud Knowledge Centre article about whitelisting public IP's on your openshift routes | UKCloud Ltd
+description: Restrict access to openshift routes by public IP[s]
+services: openshift
+author: Mudasar Hussain
+toc_rootlink: How To
+toc_sub1: 
+toc_sub2:
+toc_sub3:
+toc_sub4:
+toc_title: restrict access to openshift routes by public IP[s]
+toc_fullpath: How To/restricting-access-to-openshift-routes-by-ip.md
+toc_mdlink: oshift-how-restrict-access-to-openshift-routes-by-ip.md
+---
+
+# How to restrict access to a route in openshift by IP[s] address
+
+## Overview
+
+This knowledge centre article explains how openshift customers can restrict access to the routes they create to their deployed services by IP[s] addresses.
+
+### Intended audience
+
+Openshift developers who are looking to secure exposed routes of application by IP[s]
+
+### Bulleted lists
+
+  - Create and expose a route in the usual manner. Now you must add a annotation to the route along with the IP[s] that you would like to whitelist to be able to access the route. 
+
+oc annotate route <name> haproxy.router.openshift.io/ip_whitelist=<ip_address>
+
+> [!IMPORTANT]
+> Please note that you must do this for every route that you wish to apply the whitelisting to.
+
+  - If you would like to only allow a single IP address through to the route then you may do the following:-
+oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10
+
+
+  - If you would like to allow several IP's than you just seperate the IP's by a space like this:-
+oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10 192.168.1.11 192.168.1.12
+
+  - If you would like to allow an IP CIDR then you can declare it like this:-
+oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10/24
+
+  - If you would like to allow a mix of IP addresses and CIDR of a network, than you could do that by something like this:-
+oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10 180.5.61.153 192.168.1.0/24 10.0.0.0/8
+
+## Links to web pages
+
+For further infomation please see the openshift doc's here:-
+
+[Openshift Docs](https://docs.openshift.com/container-platform/3.9/architecture/networking/routes.html)
+
+
+## Feedback
+
+If you have any comments on this document or any other aspect of your UKCloud experience, send them to <products@ukcloud.com>.

--- a/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip.md
+++ b/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip.md
@@ -1,6 +1,6 @@
 ---
-title: UKCloud Knowledge Centre article about whitelisting public IP's on your openshift routes | UKCloud Ltd
-description: Restrict access to openshift routes by public IP[s]
+title: How to restrict access to a route in OpenShift by the source public IP address
+description: Restrict access to OpenShift routes by the source public IP address
 services: openshift
 author: Mudasar Hussain
 toc_rootlink: How To
@@ -8,48 +8,56 @@ toc_sub1:
 toc_sub2:
 toc_sub3:
 toc_sub4:
-toc_title: restrict access to openshift routes by public IP[s]
+toc_title: Restrict access to OpenShift routes by the source public IP address
 toc_fullpath: How To/restricting-access-to-openshift-routes-by-ip.md
 toc_mdlink: oshift-how-restrict-access-to-openshift-routes-by-ip.md
 ---
 
-# How to restrict access to a route in openshift by IP[s] address
+# How to only allow trusted IP's to be able to access routes in Openshift
 
 ## Overview
 
-This knowledge centre article explains how openshift customers can restrict access to the routes they create to their deployed services by IP[s] addresses.
+This knowledge centre article explains how OpenShift developers can restrict access to the routes they create to their deployed services in OpenShift by IP address. This can be done to increase the security of a route by only allowing trusted IP's to access the OpenShift route.
 
 ### Intended audience
 
-Openshift developers who are looking to secure exposed routes of application by IP[s]
+OpenShift developers who have already created and deployed services into OpenShift and also created routes for those services and exposed those routes. This article helps those users to further secure access to those exposed routes by restricting access to those exposed routes by only allowing trusted IP's to be able to access those routes.
 
-### Bulleted lists
+## Restricting access to a route
 
-  - Create and expose a route in the usual manner. Now you must add a annotation to the route along with the IP[s] that you would like to whitelist to be able to access the route. 
-
-oc annotate route <name> haproxy.router.openshift.io/ip_whitelist=<ip_address>
+  - After creating and exposing a route in OpenShift in the usual manner, you can then add an annotation to the route specifying the IP address(es) that you would like to whitelist.
+  
+> [!IMPORTANT]
+> Whitelisting a IP address automaticly blacklists everything else.
+  
+  You apply the annotation to a route in the following manner:
+  
+    oc annotate route <route_name> haproxy.router.openshift.io/ip_whitelist=<ip_address>
 
 > [!IMPORTANT]
-> Please note that you must do this for every route that you wish to apply the whitelisting to.
+> You must do this for every route that you wish to apply the whitelisting to.
 
-  - If you would like to only allow a single IP address through to the route then you may do the following:-
-oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10
+## Examples
 
+To allow a single IP address through to the route, use the following:
+  
+    oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10
 
-  - If you would like to allow several IP's than you just seperate the IP's by a space like this:-
-oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10 192.168.1.11 192.168.1.12
+To allow a several IP addresses through to the route, separate each IP with a space:
 
-  - If you would like to allow an IP CIDR then you can declare it like this:-
-oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10/24
+    oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10 192.168.1.11 192.168.1.12
 
-  - If you would like to allow a mix of IP addresses and CIDR of a network, than you could do that by something like this:-
-oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10 180.5.61.153 192.168.1.0/24 10.0.0.0/8
+To allow a network CIDR through to the route, decrlare the network CIDR as so:
 
-## Links to web pages
+    oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10/24
 
-For further infomation please see the openshift doc's here:-
+You can even use a mix of IP addresses and a network CIDR:
 
-[Openshift Docs](https://docs.openshift.com/container-platform/3.9/architecture/networking/routes.html)
+    oc annotate route myroute haproxy.router.openshift.io/ip_whitelist=192.168.1.10 180.5.61.153 192.168.1.0/24 10.0.0.0/8
+
+## More information
+
+For further infomation, see the following: [Openshift Documentation](https://docs.openshift.com/container-platform/3.9/architecture/networking/routes.html)
 
 
 ## Feedback

--- a/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip.md
+++ b/articles/openshift/oshift-how-restrict-access-to-openshift-routes-by-ip.md
@@ -25,7 +25,7 @@ OpenShift developers who have already created and deployed services into OpenShi
 
 ## Restricting access to a route
 
-  - After creating and exposing a route in OpenShift in the usual manner, you can then add an annotation to the route specifying the IP address(es) that you would like to whitelist.
+After creating and exposing a route in OpenShift in the usual manner, you can then add an annotation to the route specifying the IP address(es) that you would like to whitelist.
   
 > [!IMPORTANT]
 > Whitelisting a IP address automaticly blacklists everything else.


### PR DESCRIPTION
Article to explain how to restrict access to a openshift route by source IP address.