### PR TITLE
Update ptl-ref-portal-api.md

### DIFF
--- a/articles/portal/ptl-ref-portal-api.md
+++ b/articles/portal/ptl-ref-portal-api.md
@@ -73,7 +73,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -c /tmp/cookies.txt -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d '{"email": "email\@example.com", "password": "password"}' https://portal.skyscapecloud.com/api/authenticate
+curl -c /tmp/cookies.txt -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d '{"email": "email@example.com", "password": "password"}' https://portal.skyscapecloud.com/api/authenticate
 ```
 
 #### Example request (Ruby)


### PR DESCRIPTION
Example auth curl request doesn't work as is, two quotes were escaped without needing to be