### PR TITLE
Firewall nat warning

### DIFF
--- a/articles/vmware/vmw-gs-build-vm-vcd91.md
+++ b/articles/vmware/vmw-gs-build-vm-vcd91.md
@@ -114,6 +114,9 @@ First, you need to create a network that can connect to external networks outsid
 
 The edge gateway is possibly the most complex part of the VDC because of its high level of functionality. The following steps show you how to quickly configure the edge gateway to enable you to access the internet from a VM.
 
+> [!NOTE]
+> NAT rules will only work if firewall is enabled. For security reasons, the firewall should always be enabled.
+
 1. In the vCloud Director *Virtual Datacenters* dashboard, select your VDC.
 
 2. This time you're working with the edge gateway, so in the left navigation panel, click **Edges**.

--- a/articles/vmware/vmw-how-create-firewall-rules.md
+++ b/articles/vmware/vmw-how-create-firewall-rules.md
@@ -35,6 +35,10 @@ The steps for creating firewall rules vary depending on what type of edge gatewa
 > [!NOTE]
 > We recommend that you convert your edge to an advanced gateway to access the latest vCloud Director functionality. For more information, see [*How to convert your edge to an advanced gateway*](vmw-how-convert-edge.md).
 
+> [!NOTE]
+> For security reasons, the firewall should always be enabled. NAT rules will only work if firewall is enabled.
+> At your own risk, if you don't require the firewall to block ports then the firewall should be left enabled and the "Default Action" or the Default Rule set to Allow. This will allow NAT to still function.
+
 ## Creating firewall rules for an advanced gateway
 
 To create a firewall rule on an advanced gateway:

--- a/articles/vmware/vmw-how-create-firewall-rules.md
+++ b/articles/vmware/vmw-how-create-firewall-rules.md
@@ -36,8 +36,7 @@ The steps for creating firewall rules vary depending on what type of edge gatewa
 > We recommend that you convert your edge to an advanced gateway to access the latest vCloud Director functionality. For more information, see [*How to convert your edge to an advanced gateway*](vmw-how-convert-edge.md).
 
 > [!NOTE]
-> For security reasons, the firewall should always be enabled. NAT rules will only work if firewall is enabled.
-> At your own risk, if you don't require the firewall to block ports then the firewall should be left enabled and the "Default Action" or the Default Rule set to Allow. This will allow NAT to still function.
+> NAT rules will only work if firewall is enabled. For security reasons, the firewall should always be enabled.
 
 ## Creating firewall rules for an advanced gateway
 

--- a/articles/vmware/vmw-how-create-nat-rules.md
+++ b/articles/vmware/vmw-how-create-nat-rules.md
@@ -43,6 +43,9 @@ The steps for creating NAT rules vary depending on what type of edge gateway you
 > [!NOTE]
 > We recommend that you convert your edge to an advanced gateway to access the latest vCloud Director functionality. For more information, see [*How to convert your edge to an advanced gateway*](vmw-how-convert-edge.md).
 
+> [!NOTE]
+> NAT rules will only work if firewall is enabled. For security reasons, the firewall should always be enabled.
+
 ## Creating NAT rules for an advanced gateway
 
 ### Creating a DNAT rule for an advanced gateway

--- a/articles/vmware/vmw-ref-naming-vms.md
+++ b/articles/vmware/vmw-ref-naming-vms.md
@@ -1,5 +1,5 @@
 ---
-title: Naming virtual manchines | UKCloud Ltd
+title: Naming virtual machines | UKCloud Ltd
 description: Explains the new naming convention for virtual machines (VMs) in UKCloud for VMware
 services: vmware
 author: Sue Highmoor

--- a/articles/vmware/vmw-ref-naming-vms.md
+++ b/articles/vmware/vmw-ref-naming-vms.md
@@ -8,12 +8,12 @@ toc_sub1:
 toc_sub2:
 toc_sub3:
 toc_sub4:
-toc_title: Naming virtual manchines
+toc_title: Naming virtual machines
 toc_fullpath: Reference/vmw-ref-naming-vms.md
 toc_mdlink: vmw-ref-naming-vms.md
 ---
 
-# Naming virtual manchines
+# Naming virtual machines
 
 We're currently in the process of rolling out updates to the ESXi hosts on the UKCloud platform to version 6 to ensure platform stability and enable future feature sets. This new version implements stricter restrictions on the characters permitted for virtual machines (VMs), so you should be aware of the following:
 


### PR DESCRIPTION
It has been found that even with Standard (non-Advanced) gateways, disabling Firewall will disable NAT in vCloud 9.1.

Since it is always a good idea to have firewall enabled, I have added a note to this effect in relevant document. 

Also corrected a minor unrelated typo.