### PR TITLE
Ignore .swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ _exported_templates/
 *.nupkg
 *.log
 *.tmp
+*.swp
 *.vsprops
 *.suo
 *.user


### PR DESCRIPTION
.swp files are used by Vim to maintain which unsaved changes are made to the current buffer. However, if a file is left open in Vim while a commit is being staged, there's a chance it could get added to the commit unnecessarily.