### PR TITLE
Fix heading layouts

### DIFF
--- a/custom_template/partials/affix.tmpl.partial
+++ b/custom_template/partials/affix.tmpl.partial
@@ -2,22 +2,6 @@
 
 <div class="hidden-sm col-md-2" role="complementary">
   <div class="sideaffix">
-    {{^_disableContribution}}
-    <div class="contribution">
-      <ul class="nav">
-        {{#docurl}}
-        <li>
-          <a href="{{docurl}}" class="contribution-link">{{__global.improveThisDoc}}</a>
-        </li>
-        {{/docurl}}
-        {{#sourceurl}}
-        <li>
-          <a href="{{sourceurl}}" class="contribution-link">{{__global.viewSource}}</a>
-        </li>
-        {{/sourceurl}}
-      </ul>
-    </div>
-    {{/_disableContribution}}
     <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
     <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
     </nav>

--- a/custom_template/partials/breadcrumb.tmpl.partial
+++ b/custom_template/partials/breadcrumb.tmpl.partial
@@ -1,7 +1,25 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
 <div class="navbar-borderless subnav navbar navbar-default">
-  <div class="container-fluid hide-when-search subnav-margin-left" id="breadcrumb">
+  <div class="navbar-right subnav-margin-right">
+    {{^_disableContribution}}
+      <div class="contribution">
+        <ul class="nav">
+          {{#docurl}}
+          <li>
+            <a href="{{docurl}}" class="contribution-link">{{__global.improveThisDoc}}</a>
+          </li>
+          {{/docurl}}
+          {{#sourceurl}}
+          <li>
+            <a href="{{sourceurl}}" class="contribution-link">{{__global.viewSource}}</a>
+          </li>
+          {{/sourceurl}}
+        </ul>
+      </div>
+    {{/_disableContribution}}
+  </div>
+  <div class="hide-when-search subnav-margin-left" id="breadcrumb">
     <ul class="breadcrumb">
       <li>{{_tocTitle}}</li>
     </ul>

--- a/custom_template/styles/docfx.css
+++ b/custom_template/styles/docfx.css
@@ -573,7 +573,7 @@ body .toc{
   left: 5px;
 }
 .article {
-  margin-top: 120px;
+  margin-top: 78px;
   margin-bottom: 115px;
 }
 
@@ -593,7 +593,7 @@ body .toc{
   max-width: 100%;
 }
 .sideaffix {
-  margin-top: 50px;
+  margin-top: 10px;
   font-size: 12px;
   max-height: 100%;
   overflow: hidden;

--- a/custom_template/styles/main.css
+++ b/custom_template/styles/main.css
@@ -85,6 +85,10 @@ a:hover {
   margin-left: 25px;
 }
 
+.subnav-margin-right {
+  margin-right: 25px;
+}
+
 .navbar-margin-left {
   margin-left: 15px;
   padding-left: 15px;


### PR DESCRIPTION
Moves the 'Improve this doc' link and brings up the page content to remove the 40px margin above the main heading