### PR TITLE
Change links to MTF service scopes

### DIFF
--- a/articles/enablement/enbl-ref-services.md
+++ b/articles/enablement/enbl-ref-services.md
@@ -33,7 +33,7 @@ Other enablement services that we provide to help you work with our cloud platfo
 
 - Data Transfer Facility - Enables you to use the secure network connections at our Farnborough office to manage systems or transfer data into or out of your environments. For more information, see the [*Data Transfer Facility Service Scope*](enbl-sco-dtf.md).
 
-- Mass Data Transfer (HDD) - Enables you to move virtualised environments, in the form of VMs, into or out of your UKCloud environment using your own NAS, HDD, or USB devices. For more information, see the [*Mass Transfer Facility Service Scope*](enbl-sco-mtf-nas.md).
+- Mass Data Transfer - Enables you to move virtualised environments, in the form of VMs, into or out of your UKCloud environment using your own NAS, HDD, or USB devices. For more information, see the [*Mass Transfer Facility Service Scope*](enbl-sco-mtf-nas.md).
 
 - Smart Hands - This service can be used for a number of different requirements such as a physical 'push-button' task, replacing hardware and checking equipment statuses. For more information, see the [*Smart Hands Service Scope*](enbl-sco-smart-hands.md).
 

--- a/articles/enablement/enbl-ref-services.md
+++ b/articles/enablement/enbl-ref-services.md
@@ -33,9 +33,7 @@ Other enablement services that we provide to help you work with our cloud platfo
 
 - Data Transfer Facility - Enables you to use the secure network connections at our Farnborough office to manage systems or transfer data into or out of your environments. For more information, see the [*Data Transfer Facility Service Scope*](enbl-sco-dtf.md).
 
-- Mass Data Transfer (HDD) - Enables you to move virtualised environments, in the form of VMs, into or out of your UKCloud environment using your own hard disk drives (HDDs). For more information, see the [*Mass Transfer Facility - HDD Service Scope*](enbl-sco-mtf-hdd.md).
-
-- Mass Data Transfer (NAS) - Enables you to move virtualised environments, in the form of VMs, into and out of your UKCloud environment using your own network attached storage (NAS) device. For more information, see the [*Mass Transfer Facility - NAS Service Scope*](enbl-sco-mtf-nas.md).
+- Mass Data Transfer (HDD) - Enables you to move virtualised environments, in the form of VMs, into or out of your UKCloud environment using your own NAS, HDD, or USB devices. For more information, see the [*Mass Transfer Facility Service Scope*](enbl-sco-mtf-nas.md).
 
 - Smart Hands - This service can be used for a number of different requirements such as a physical 'push-button' task, replacing hardware and checking equipment statuses. For more information, see the [*Smart Hands Service Scope*](enbl-sco-smart-hands.md).
 

--- a/articles/enablement/enbl-sco-dtf.md
+++ b/articles/enablement/enbl-sco-dtf.md
@@ -27,7 +27,7 @@ Our Data Transfer Facility enables customers to use the secure network connectio
 
 It's useful if, for example, you don't have enough network bandwidth, or you're waiting for appropriately accredited connectivity to be installed.
 
-If you want to bring in more than 500GiB of VMs, we also offer a Mass Transfer facility, see the appropriate Service Scope for [NAS](enbl-sco-mtf-nas.md) or [HDD](enbl-sco-mtf-hdd.md).
+If you want to bring in more than 500GiB of VMs, we also offer a [Mass Transfer facility](enbl-sco-mtf-nas.md).
 
 ## Booking and booking conditions
 

--- a/articles/vmware/vmw-faq.md
+++ b/articles/vmware/vmw-faq.md
@@ -120,7 +120,7 @@ For a transfer time calculator, go to: <http://techinternets.com/copy_calc?do>
 
 If you use FTPS to upload data to or download it from your environment, you can transfer up to 1TiB of data in a day.
 
-Alternatively, we offer the Mass Transfer Facility option enabling customers to import large quantities of data via HDDs or NAS devices that are plugged directly into your environment. Please check the *Mass Transfer Facility Service Scope* for [NAS](../enablement/enbl-sco-mtf-nas.md) or [HDD](../enablement/enbl-sco-mtf-hdd.md), or the [*UKCloud Pricing Guide*](https://ukcloud.com/wp-content/uploads/2019/06/ukcloud-pricing-guide-11.0.pdf) further details.
+Alternatively, we offer the Mass Transfer Facility option enabling customers to import large quantities of data via HDDs or NAS devices that are plugged directly into your environment. Please check the [*Mass Transfer Facility Service Scope*](../enablement/enbl-sco-mtf-nas.md) or the [*UKCloud Pricing Guide*](https://ukcloud.com/wp-content/uploads/2019/06/ukcloud-pricing-guide-11.0.pdf) further details.
 
 ### Does UKCloud offer encryption on the VM?
 

--- a/articles/vmware/vmw-faq.md
+++ b/articles/vmware/vmw-faq.md
@@ -120,7 +120,7 @@ For a transfer time calculator, go to: <http://techinternets.com/copy_calc?do>
 
 If you use FTPS to upload data to or download it from your environment, you can transfer up to 1TiB of data in a day.
 
-Alternatively, we offer the Mass Transfer Facility option enabling customers to import large quantities of data via HDDs or NAS devices that are plugged directly into your environment. Please check the [*Mass Transfer Facility Service Scope*](../enablement/enbl-sco-mtf-nas.md) or the [*UKCloud Pricing Guide*](https://ukcloud.com/wp-content/uploads/2019/06/ukcloud-pricing-guide-11.0.pdf) further details.
+Alternatively, we offer the Mass Transfer Facility option enabling customers to import large quantities of data via NAS, HDD or USB devices that are plugged directly into your environment. Please check the [*Mass Transfer Facility Service Scope*](../enablement/enbl-sco-mtf-nas.md) or the [*UKCloud Pricing Guide*](https://ukcloud.com/wp-content/uploads/2019/06/ukcloud-pricing-guide-11.0.pdf) further details.
 
 ### Does UKCloud offer encryption on the VM?
 

--- a/docs/articles/enablement/enbl-ref-services.html
+++ b/docs/articles/enablement/enbl-ref-services.html
@@ -108,9 +108,7 @@
 <ul>
 <li><p>Data Transfer Facility - Enables you to use the secure network connections at our Farnborough office to manage systems or transfer data into or out of your environments. For more information, see the <a href="enbl-sco-dtf.html"><em>Data Transfer Facility Service Scope</em></a>.</p>
 </li>
-<li><p>Mass Data Transfer (HDD) - Enables you to move virtualised environments, in the form of VMs, into or out of your UKCloud environment using your own hard disk drives (HDDs). For more information, see the <a href="enbl-sco-mtf-hdd.html"><em>Mass Transfer Facility - HDD Service Scope</em></a>.</p>
-</li>
-<li><p>Mass Data Transfer (NAS) - Enables you to move virtualised environments, in the form of VMs, into and out of your UKCloud environment using your own network attached storage (NAS) device. For more information, see the <a href="enbl-sco-mtf-nas.html"><em>Mass Transfer Facility - NAS Service Scope</em></a>.</p>
+<li><p>Mass Data Transfer - Enables you to move virtualised environments, in the form of VMs, into or out of your UKCloud environment using your own NAS, HDD or USB devices. For more information, see the <a href="enbl-sco-mtf-nas.html"><em>Mass Transfer Facility Service Scope</em></a>.</p>
 </li>
 <li><p>Smart Hands - This service can be used for a number of different requirements such as a physical 'push-button' task, replacing hardware and checking equipment statuses. For more information, see the <a href="enbl-sco-smart-hands.html"><em>Smart Hands Service Scope</em></a>.</p>
 </li>


### PR DESCRIPTION
Change links to Mass Transfer Facility service scopes to prevent broken links when removing old HDD specific article