### PR TITLE
Update third-sco-cyberscore.md

### DIFF
--- a/articles/third-party/third-sco-cyberscore.md
+++ b/articles/third-party/third-sco-cyberscore.md
@@ -55,9 +55,7 @@ CyberScore provides the following key features:
 
 - **Service Delivery Manager**.  You'll be allocated with an assigned point of contact who will provide ongoing assistance with reporting and incident escalation.
 
-- **Support**. After the initial on-boarding, you can utilise the standard UKCloud support entitlement, which is documented in the [Customer Engagement Factsheet](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf). UKCloud can help with remediation of the service.
-
-- XQ Cyber have created help notes, set-up guides and support pages within the [CyberScore web interface](https://xqcyber.com/cyberscore)<sup>*</sup>.
+- **Support**. After the initial on-boarding, you can utilise the standard UKCloud support entitlement, which is documented in the [Customer Engagement Factsheet](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
 
 ## Customer responsibilities
 

--- a/articles/third-party/third-sco-cyberscore.md
+++ b/articles/third-party/third-sco-cyberscore.md
@@ -17,8 +17,6 @@ toc_mdlink: third-sco-cyberscore.md
 
 # CyberScore from UKCloud Service Scope
 
-<sup>*</sup> All links to CyberScore support documents will require you to log in.
-
 ## About this document
 
 This document describes the boundaries of the CyberScore&trade; from UKCloud (CyberScore) service, along with the division of responsibilities between UKCloud, XQ Cyber and the customer, to facilitate the provisioning and ongoing use of the service.


### PR DESCRIPTION
Removed "UKCloud can help with remediation of the service.
XQ Cyber have created help notes, set-up guides and support pages within the CyberScore web interface*." because remediation is covered by the section "Remediation of security vulnerabilities" lower down, and the point about the support docs is more of a "how to" or "getting started" point and also refers to XQ Cyber which will cause confusion.