### PR TITLE
Avoid writing credentials into shell commands

### DIFF
--- a/articles/other/other-ref-idam.md
+++ b/articles/other/other-ref-idam.md
@@ -35,11 +35,18 @@ This article provides examples using [`curl`](https://curl.haxx.se/) and [`jq`](
 Before you begin, you'll need to retrieve a single sign-on token to authenticate with IDAM. For ease of use, this is saved to a variable `token` in your current shell session using the below command.
 
 ```sh
+echo "enter your Portal email address"
+read username
+echo "enter your Portal password"
+read -s password
+
 token=$(curl -X POST "https://idp.ukcloud.com/auth/realms/client-assured/protocol/openid-connect/token" \
-     -d username="<username>" \
-     -d password="<password>"  \
-     -d grant_type=password    \
+     -d "username=$username" \
+     -d "password=$password" \
+     -d grant_type=password \
      -d client_id=portal.ukcloud | jq -r '.access_token')
+
+unset password
 ```
 
 This token is used in bearer authentication with IDAM. Requests to the IDAM API are prefaced with `curl -H "Authorization: Bearer $token"`.


### PR DESCRIPTION
It is safer to use `read -s` to put passwords into environment variables
because:
1. People looking over your shoulder can't read them off your screen.
2. They don't appear in your shell history.

It's worth noting it is still not totally secure.
If you don't run the `unset` command, people using your shell,
malicious shell commands and shell commands that don't realise the
sensitivity of the environment variables can read the password.