### PR TITLE
Update cs-ref-s3-examples.md

### DIFF
--- a/articles/cloud-storage/cs-ref-s3-examples.md
+++ b/articles/cloud-storage/cs-ref-s3-examples.md
@@ -17,11 +17,9 @@ toc_mdlink: cs-ref-s3-examples.md
 
 # S3-compatible API examples for Cloud Storage
 
+UKCloud provides a project in our GitHub repository that contains sample code for common operations against UKCloud's ECS-based Cloud Storage service. While ECS itself supports both an S3 compatible and an EMC native API, the samples in this repository are designed to work with the S3-compatible endpoint only.
+
 These examples show common operations in different languages, including Ruby and Python.
-
-**ECS examples:**
-
-This project contains sample code for common operations against UKCloud's ECS based Cloud Storage service. Whilst ECS itself supports both an S3 compatible and an EMC native API the samples in this repository are designed to work with the S3 compatible endpoint only.
 
 You can find the examples in our GitHub repository here: <https://github.com/UKCloud/ecs-s3-examples>
 

--- a/articles/cloud-storage/cs-ref-s3-examples.md
+++ b/articles/cloud-storage/cs-ref-s3-examples.md
@@ -3,8 +3,8 @@ title: S3-compatible API examples for Cloud Storage | UKCloud Ltd
 description: Provides links to examples of how to use the S3-compatible API with UKCloud’s Cloud Storage service
 services: cloud-storage
 author: Sue Highmoor
-reviewer:
-lastreviewed: 17/07/2018 16:46:31
+reviewer: George Smith
+lastreviewed: 15/11/2019 16:46:31
 toc_rootlink: Reference
 toc_sub1: 
 toc_sub2:
@@ -19,15 +19,11 @@ toc_mdlink: cs-ref-s3-examples.md
 
 These examples show common operations in different languages, including Ruby and Python.
 
-You can find the examples in our GitHub repository.
-
 **ECS examples:**
 
-<https://github.com/UKCloud/ecs-s3-examples>
+This project contains sample code for common operations against UKCloud's ECS based Cloud Storage service. Whilst ECS itself supports both an S3 compatible and an EMC native API the samples in this repository are designed to work with the S3 compatible endpoint only.
 
-**Atmos examples:**
-
-<https://github.com/UKCloud/atmos-s3-examples>
+You can find the examples in our GitHub repository here: <https://github.com/UKCloud/ecs-s3-examples>
 
 ## Feedback
 


### PR DESCRIPTION
Removed Atmos examples as they are not longer supported by UKC.
I have emailed cblackuk about the ecs git examples for ecs to validate they are still correct.