### PR TITLE
Update docfx.json

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -30,7 +30,7 @@
     ],
     "overwrite": [],
     "globalMetadata": {
-      "_appTitle": "UKCloud Knowledge Centre",
+      "_appTitle": "",
       "_appFaviconPath": "favicon.ico",
       "_appLogoPath": "logo.png",
       "_enableSearch": true,


### PR DESCRIPTION
Changing appTitle so that DocFX doesn't automatically append a load of characters to every article title. Should help fix a majority of the "title too long" SEO errors