### PR TITLE
Restrict new VDC names to alphanumeric characters

### DIFF
--- a/articles/portal/ptl-ref-portal-api.md
+++ b/articles/portal/ptl-ref-portal-api.md
@@ -1856,7 +1856,7 @@ v1
 Parameter name | Description | Type | Mandatory (Default)
 ---------------|-------------|------|--------------------
 vmType | The type of VM workloads used in the VDC</br>Valid values:</br>- POWER</br>- ESSENTIAL</br>- PRIORITY | String | Y
-name | The name of the VDC<br>The name can be up to 32 characters long and can include any character except + | String | Y
+name | The name of the VDC<br>The name can be up to 32 characters long and can include any alphanumeric character | String | Y
 
 #### URI parameters
 

--- a/articles/portal/ptl-ref-portal-api.md
+++ b/articles/portal/ptl-ref-portal-api.md
@@ -1856,7 +1856,7 @@ v1
 Parameter name | Description | Type | Mandatory (Default)
 ---------------|-------------|------|--------------------
 vmType | The type of VM workloads used in the VDC</br>Valid values:</br>- POWER</br>- ESSENTIAL</br>- PRIORITY | String | Y
-name | The name of the VDC<br>The name can be up to 32 characters long and can include any alphanumeric character | String | Y
+ name | The name of the VDC<br />The name can be up to 32 characters long and can include any character except `+`, `(` or `)` | String | Y
 
 #### URI parameters
 

--- a/articles/vmware/vmw-gs.md
+++ b/articles/vmware/vmw-gs.md
@@ -157,7 +157,7 @@ After creating your compute service, the next step is to create one or more VDCs
 4. Enter a **VDC Name**.
 
     > [!TIP]
-    > The name can be up to 32 characters long and can include any character except +.
+    > The name can be up to 32 characters long and can include any character except `+`, `(` or `)`.
 
     ![Build VDC page](images/vmw-portal-build-vdc.png)
 


### PR DESCRIPTION
This is due to a bug in the current version of vCloud director.
SEMPS-3419