### PR TITLE
Update ptl-ref-overview-permissions.md

### DIFF
--- a/articles/portal/ptl-ref-overview-permissions.md
+++ b/articles/portal/ptl-ref-overview-permissions.md
@@ -23,7 +23,7 @@ System administrators are presented with several options to control user permiss
 
 ![Portal permissions page](images/portal_permissions.png)
 
-> [!NOTE]
+> [NOTE]
 > Selecting API only is not a permission level by itself. You are still required to choose one of the following Admin, Catalogue Author, vApp Author, vApp User or Console Only. 
 
 ## User is admin?

--- a/articles/portal/ptl-ref-overview-permissions.md
+++ b/articles/portal/ptl-ref-overview-permissions.md
@@ -3,8 +3,8 @@ title: Portal permissions
 description: A guide to the various permissions available to Portal users and what behaviour they enable
 services: portal
 author: Sue Highmoor
-reviewer: aperrett
-lastreviewed: 23/10/2019
+reviewer: Gsmith
+lastreviewed: 25/02/2020
 toc_rootlink: Reference
 toc_sub1:
 toc_sub2:
@@ -22,6 +22,9 @@ toc_mdlink: ptl-ref-overview-permissions.md
 System administrators are presented with several options to control user permissions through the UKCloud Portal. The information below is intended as a brief guide to which permissions are applied using each setting.
 
 ![Portal permissions page](images/portal_permissions.png)
+
+> [!NOTE]
+> Selecting API only is not a permission level by itself. You are still required to choose one of the following Admin, Catalogue Author, vApp Author, vApp User or Console Only. 
 
 ## User is admin?
 

--- a/articles/portal/ptl-ref-overview-permissions.md
+++ b/articles/portal/ptl-ref-overview-permissions.md
@@ -23,9 +23,6 @@ System administrators are presented with several options to control user permiss
 
 ![Portal permissions page](images/portal_permissions.png)
 
-> [NOTE]
-> Selecting API only is not a permission level by itself. You are still required to choose one of the following Admin, Catalogue Author, vApp Author, vApp User or Console Only. 
-
 ## User is admin?
 
 User gets full administrative privileges across the entire account. This includes all of the permissions listed below.
@@ -60,7 +57,7 @@ Support permissions dictate whether a user can view other users support tickets.
 
 ## Permissions for UKCloud for VMware
 
-Compute service permissions are based on the vCloud director RBAC (role based access control permissions). These roles are applied on a service by service basis - for example someone might be a catalogue author of one service, and a console only user in a secondary service.
+Compute service permissions are based on the vCloud Director RBAC (role based access control) permissions. These roles are applied on a service by service basis - for example someone might be a Catalogue Author of one service, and a Console Only user in a second service.
 
 The roles exposed are:
 
@@ -76,7 +73,10 @@ The roles exposed are:
 
 You can find further details of these roles in the [vCloud Director Administrator's Guide](https://docs.vmware.com/en/vCloud-Director/9.7/com.vmware.vcloud.admin.doc/GUID-BC504F6B-3D38-4F25-AACF-ED584063754F.html).
 
-In addition, UKCloud have created an API Only role, that restricts users to accessing vCloud Director solely via the API, with no GUI access.
+In addition, UKCloud have created an API Only role that restricts users with vCloud Director permissions to accessing vCloud Director solely via the API, with no GUI access.
+
+> [NOTE]
+> The API Only role must be selected in addition to one of the vCloud Director roles (Admin, Catalogue Author, vApp Author, vApp User or Console Only); you should not select the API Only role on its own.
 
 ## Permissions for Cloud Storage
 

--- a/articles/portal/ptl-ref-overview-permissions.md
+++ b/articles/portal/ptl-ref-overview-permissions.md
@@ -57,7 +57,7 @@ Support permissions dictate whether a user can view other users support tickets.
 
 ## Permissions for UKCloud for VMware
 
-Compute service permissions are based on the vCloud Director RBAC (role based access control) permissions. These roles are applied on a service by service basis - for example someone might be a Catalogue Author of one service, and a Console Only user in a second service.
+UKCloud for VMware service permissions are based on the vCloud Director RBAC (role based access control) permissions. These roles are applied on a service by service basis - for example someone might be a Catalogue Author of one service, and a Console Only user in a second service.
 
 The roles exposed are:
 


### PR DESCRIPTION
Adding a not about the API only setting. 

We get tickets from customers that are confused about this setting not realising that they have to select another permission option not just api only by itself. 