### PR TITLE
Add new OpenStack services

### DIFF
--- a/articles/other/other-faq-billing.md
+++ b/articles/other/other-faq-billing.md
@@ -144,11 +144,11 @@ The [*How to use VM location in vCloud Director*](../vmware/vmw-how-use-vm-locat
 
 The cost of your UKCloud for OpenStack instances is determined by adding together the cost of your compute and storage. You can find these individual costs in the following columns of the evidence file in rows of the service type (column H) of `OpenStack Virtual Machine`:
 
-Description           | Column
-----------------------|-------
-Compute               | U
-Tier 1 Storage        | AE
-Tier 2 Storage        | AK
+Description                           | Column
+--------------------------------------|-------
+Compute                               | U
+Tier 1 Storage (or Encrypted Storage) | AE
+Tier 2 Storage (or Encrypted Storage) | AK
 
 The compute cost of an instance (column U) is determined by the instance size (column O), security domain (column Q), vCPU (column R), and memory (column S).
 
@@ -158,7 +158,7 @@ When you shelve an OpenStack instance, all compute charges for that instance cea
 
 ### How much block storage are my instances using?
 
-Block storage for OpenStack instances is included in the evidence as separate line items with the service type (column H) of `OpenStack Block Storage Tier 1` or `OpenStack Block Storage Tier 2`.
+Block storage for OpenStack instances is included in the evidence as separate line items with the service type (column H) of `OpenStack Block Storage Tier 1` or `OpenStack Block Storage Tier 2` or `OpenStack Block Storage Tier 1 Encrypted` or `OpenStack Block Storage Tier 2 Encrypted`.
 
 The amount and cost of block storage is provided in the following columns:
 
@@ -169,7 +169,7 @@ Tier 1 Storage cost        | AE
 Tier 2 Storage used        | AF
 Tier 2 Storage cost        | AK
 
-UKCloud for OpenStack storage costs also include any images you have, which are listed as separate rows in the evidence file. Look for rows with the service type (column H) of `OpenStack Image`.
+UKCloud for OpenStack storage costs also include any images and backups you have, which are listed as separate rows in the evidence file. Look for rows with the service type (column H) of `OpenStack Image` and `OpenStack Instance Backup Storage`.
 
 ## Cloud GPU charges
 

--- a/articles/other/other-ref-invoice-evidence-file.md
+++ b/articles/other/other-ref-invoice-evidence-file.md
@@ -38,7 +38,7 @@ D      | vDC                               | Name of the virtual data centre | V
 E      | ResourceName                      | Client-friendly name of the resource | OpenStack, VMware
 F      | Resource Id                       | Identifier of the resource | OpenStack, VMware
 G      | OSID                              | Operating system | VMware
-H      | Service                           | The UKCloud service to which the charge applies:<br>OpenStack Virtual Machine<br>OpenStack Block Storage Tier 1<br>OpenStack Block Storage Tier 2<br>OpenStack Image<br>CDSZ Walled Garden<br>Disaster Recovery as a Service<br>High Performance Compute<br>Secure Remote Access<br>VMware Dedicated VM<br>VMware Independent Disk<br>VMware Media<br>VMware Template<br>VMware VM | OpenStack, VMware
+H      | Service                           | The UKCloud service to which the charge applies:<br>OpenStack Virtual Machine<br>OpenStack Block Storage Tier 1<br>OpenStack Block Storage Tier 1 Encrypted<br>OpenStack Block Storage Tier 2<br>OpenStack Block Storage Tier 2 Encrypted<br>OpenStack Image<br>OpenStack Instance Backup Storage<br>CDSZ Walled Garden<br>Disaster Recovery as a Service<br>High Performance Compute<br>Secure Remote Access<br>VMware Dedicated VM<br>VMware Independent Disk<br>VMware Media<br>VMware Template<br>VMware VM | OpenStack, VMware
 I      | Metadata                          | Customer VM metadata | VMware
 J      | StartTime                         | Charging period start time on the EventDate, in UTC | OpenStack, VMware
 K      | EndTime                           | Charging period end time on the EventDate, in UTC | OpenStack, VMware
@@ -74,7 +74,7 @@ AN     | Geo-resilientStorageIncluded      | Geo-resilient storage amount that i
 AO     | Geo-resilientStorageChargeable    | Geo-resilientSnapshotStorageUsed + Geo-resilientSnapshotStorageUsed - Geo-resilientStorageIncluded | VMware
 AP     | Geo-resilientPricePerHour         | Service catalogue price for geo-resilient storage and security domain converted into hourly charge per GiB | VMware
 AQ     | Geo-resilientStoragePrice         | Geo-resilientStorageChargeable * Geo-resilientStoragePricePerHour * UsageHoursWithinPeriod | VMware
-AR     | Protection Type                   | Type of protection applied:<br>None<br>14 Day Snapshot Protection<br>28 Day Snapshot Protection<br>Synchronous Protection<br>2 Day Journaling Protection<br>7 Day Journaling Protection<br>14 Day Journaling Protection<br>28 Day Journaling Protection<br>Any combination of the above (apart from None) separated by & | VMware
+AR     | Protection Type                   | Type of protection applied:<br>None<br>Backup Storage<br>14 Day Snapshot Protection<br>28 Day Snapshot Protection<br>Synchronous Protection<br>2 Day Journaling Protection<br>7 Day Journaling Protection<br>14 Day Journaling Protection<br>28 Day Journaling Protection<br>Any combination of the above (apart from None) separated by & | OpenStack, VMware
 AS     | ComputeProtectionPerHour          | Price per hour dependent on values in Protection Type (taking into account free 14 day snapshot with synchronous) | VMware
 AT     | ComputeProtectionTotalPrice       | ComputeProtectionPerHour * UsageHoursWithinPeriod | VMware
 AU     | Tier1ProtectionPricePerHour       | Monthly charge from service catalogue (per GB per month) converted into hourly charge per GiB (0 if no protection; blank if not relevant) | VMware
@@ -90,6 +90,18 @@ BD     | TotalPrice                        | ComputeTotalPrice + GPUTotalPrice +
 
 ## Key changes to the Evidence File (November 2017 onwards)
 
+### March 2020
+
+Support for new OpenStack services has been added to the evidence files.
+
+- Column H : has 3 new service types
+    - OpenStack Block Storage Tier 1 Encrypted
+    - OpenStack Block Storage Tier 1 Encrypted
+    - OpenStack Instance Backup Storage
+- Column AR : OpenStack Instance Backup Storage has a Protection Type of "Backup Storage".
+
+### December 2018
+
 From December 2018, you'll see the following changes to your evidence file. You'll receive the Evidence File for December at the start of January 2019, detailing your consumption during December.
 
 The key changes to the evidence file are as follows:
@@ -97,8 +109,6 @@ The key changes to the evidence file are as follows:
 **Service type categories**
 
 - In column H the OpenStack Instance service type has been renamed to OpenStack Virtual Machine
-
-## Previous changes
 
 ### November 2017
 

--- a/articles/other/other-ref-invoice-evidence-file.md
+++ b/articles/other/other-ref-invoice-evidence-file.md
@@ -96,7 +96,7 @@ Support for new OpenStack services has been added to the evidence files.
 
 - Column H : has 3 new service types
     - OpenStack Block Storage Tier 1 Encrypted
-    - OpenStack Block Storage Tier 1 Encrypted
+    - OpenStack Block Storage Tier 2 Encrypted
     - OpenStack Instance Backup Storage
 - Column AR : OpenStack Instance Backup Storage has a Protection Type of "Backup Storage".
 


### PR DESCRIPTION
There are now 3 new OpenStack services which can appear in the evidence files. Encrypted Storage (Tier 1 and Tier 2) and Backup Storage. This change documents the names of those services as they will appear from March 2020.