### PR TITLE
Reviewed azs-how-create-aks

### DIFF
--- a/articles/azure/azs-how-create-aks.md
+++ b/articles/azure/azs-how-create-aks.md
@@ -3,8 +3,8 @@ title: How to create an Azure Kubernetes Service cluster using the UKCloud Azure
 description: Create an Azure Kubernetes Service cluster using Azure Stack Hub
 services: azure-stack
 author: Bailey Lawson
-reviewer: BaileyLawson
-lastreviewed: 14/03/2019 17:00:00
+reviewer: William Turner
+lastreviewed: 03/04/2020
 
 toc_rootlink: Users
 toc_sub1: How To

--- a/articles/azure/azs-how-create-aks.md
+++ b/articles/azure/azs-how-create-aks.md
@@ -18,6 +18,9 @@ toc_mdlink: azs-how-create-aks.md
 
 # How to create an Azure Kubernetes Service cluster using the UKCloud Azure Stack Hub portal
 
+> [!WARNING]
+> Using the Kubernetes Azure Stack Hub Marketplace item to deploy clusters is now deprecated and should only be used as a proof-of-concept. For supported Kubernetes clusters on Azure Stack Hub, use [the AKS engine](https://docs.microsoft.com/en-us/azure-stack/user/azure-stack-kubernetes-aks-engine-overview?view=azs-2002).
+
 ## Overview
 
 Azure Kubernetes Service (AKS) makes it simple to deploy a managed Kubernetes cluster in Azure Stack Hub. AKS reduces the complexity and operational overhead of managing Kubernetes by offloading much of that responsibility to Azure Stack Hub. As a hosted Kubernetes service, Azure Stack Hub handles critical tasks like health monitoring and maintenance for you.


### PR DESCRIPTION
Reviewed article as per JIRA ticket AS-1386.
This article is now deprecated and will eventually be replaced by an article that describes how to deploy the AKS engine onto Azure Stack Hub. I have added a warning message at the top which details this.