### PR TITLE
Change CSM to SDM

### DIFF
--- a/articles/azure/azs-faq.md
+++ b/articles/azure/azs-faq.md
@@ -181,7 +181,7 @@ Yes, you can receive portal notifications to the email address associated with y
 
 ### How can I get started with the service?
 
-Once you have requested a UKCloud for Microsoft Azure environment, your Customer Success Manager (CSM) will introduce you to the platform and relevant supporting documentation.
+Once you've requested a UKCloud for Microsoft Azure environment, your Service Delivery Manager will introduce you to the platform and relevant supporting documentation.
 
 ### Is there a free trial?
 
@@ -193,7 +193,7 @@ This can be requested via the [UKCloud website trial page](https://ukcloud.com/f
 
 ### What do I do when my trial comes to an end?
 
-During your 30 day trial period, you will be contacted regularly by your Customer Success Manager who will be on hand to assist you with using the service. When your trial is nearing the 30 day limit, your Account Manager will contact you to discuss the outcome of the trial. If you wish to cancel the service, this will be done for you, and any data will be deleted and the service will be decommissioned. If you wish to commit to using the service, your trial will convert to a full paid service, and you will then be billed according to the [*Service Definition*](azs-sd.md).
+During your 30 day trial period, you will be contacted regularly by your Service Delivery Manager who will be on hand to assist you with using the service. When your trial is nearing the 30 day limit, your Account Manager will contact you to discuss the outcome of the trial. If you want to cancel the service, this will be done for you, and any data will be deleted and the service will be decommissioned. If you want to commit to using the service, your trial will convert to a full paid service, and you'll then be billed according to the [*Service Definition*](azs-sd.md).
 
 ## Billing and legal
 

--- a/articles/azure/azs-gs.md
+++ b/articles/azure/azs-gs.md
@@ -64,7 +64,7 @@ Azure Active Directory is Microsoft's cloud-based Directory and Identity Access 
 
 # [I have an existing Azure Active Directory Domain](#tab/tabid-1)
 
-If you've decided that UKCloud for Microsoft Azure is the right environment for you, contact your CSM with the following information:
+If you've decided that UKCloud for Microsoft Azure is the right environment for you, contact your Service Delivery Manager (SDM) with the following information:
 
 - Contact email address, for example, onboardingukcloud3@ukcloud.com
 
@@ -86,11 +86,11 @@ Accept the **Microsoft Store for Business and your data** agreement.
 
 ![Microsoft Store for Business Data Agreement](images/azs-browser-MS-SfB-agreement.png)
 
-After accepting the agreement you will be greeted with the following page. Tick the checkbox and click **Accept**, then contact your CSM so UKCloud can complete your onboarding process.
+After accepting the agreement you will be greeted with the following page. Tick the checkbox and click **Accept**, then contact your SDM so UKCloud can complete your onboarding process.
 
 ![Microsoft Azure authorize CSP page](images/azs-browser-authorize-csp.png)
 
-Next, you should receive a welcome email from your CSM containing the details of your new UKCloud for Microsoft Azure environment.
+Next, you should receive a welcome email from your SDM containing the details of your new UKCloud for Microsoft Azure environment.
 
 > [!IMPORTANT]
 > If you have conditional access policies enabled for your Azure Active Directory, follow the instructions from the invitation email to allow us access to your AAD.
@@ -99,7 +99,7 @@ Next, you should receive a welcome email from your CSM containing the details of
 
 # [I do not have an existing Azure Active Directory](#tab/tabid-2)
 
-If you've decided that UKCloud for Microsoft Azure is the right environment for you, contact your CSM with the following information:
+If you've decided that UKCloud for Microsoft Azure is the right environment for you, contact your Service Delivery Manager (SDM) with the following information:
 
 - Contact name, for example, John Doe
 
@@ -113,7 +113,7 @@ If you've decided that UKCloud for Microsoft Azure is the right environment for 
 
 Once you've provided this information, UKCloud will set up your new UKCloud for Microsoft Azure environment.
 
-After providing the above details, you should receive a welcome email shortly from your CSM containing the details of your new UKCloud for Microsoft Azure environment.
+After providing the above details, you should receive a welcome email shortly from your SDM containing the details of your new UKCloud for Microsoft Azure environment.
 
 ***
 

--- a/articles/azure/azs-how-use-ukc-csp.md
+++ b/articles/azure/azs-how-use-ukc-csp.md
@@ -29,7 +29,7 @@ If you already consume UKCloud for Microsoft Azure, or another UKCloud core clou
 - Access to our free 24x7 customer support
 
 > [!NOTE]
-> If you have an existing subscription that's not covered by a CSP (for example, an Enterprise Agreement subscription) this cannot be automatically used in your UKCloud public Azure environment. In this scenario, raise a service request so that we can contact you to discuss options, or speak to your Customer Success Manager or Service Delivery Manager.
+> If you have an existing subscription that's not covered by a CSP (for example, an Enterprise Agreement subscription) this cannot be automatically used in your UKCloud public Azure environment. In this scenario, raise a service request so that we can contact you to discuss options, or speak to your Service Delivery Manager.
 
 ## Prerequisites
 

--- a/articles/azure/azs-sco.md
+++ b/articles/azure/azs-sco.md
@@ -40,8 +40,6 @@ Once a purchase order is received, within 4 hours of accepting an order (shorter
 
 We've created several articles, guides and FAQs to help you get up and running quickly and easily. These are available within our Knowledge Centre.
 
-In addition, you'll be assigned a Customer Success Manager (CSM) to provide any assistance required during your initial adoption of the service.
-
 UKCloud also has a large ecosystem of partners who can deliver additional services, such as support and professional services. UKCloud would be pleased to introduce you to the right partner to suit your needs.
 
 ### Azure Stack Hub service management
@@ -280,13 +278,11 @@ UKCloud can offer additional professional and managed services in relation to Mi
 
 ## Customer service
 
-**Customer Success Manager (CSM).** During your initial time with UKCloud, you'll be assigned a CSM, who will help you with your adoption of the UKCloud for Microsoft Azure service, including finding relevant systems and using UKCloud tools and processes.
+**Cloud Architect.** Cloud Architects support you during the design of solutions for the cloud platform. Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing complex solutions, such as those using HybridConnect or a Walled Garden.
 
-**Cloud Architects.** Cloud Architects support you during the design of solutions for the cloud platform. Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing complex solutions, such as those using HybridConnect or a Walled Garden.
+**Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Service Delivery Managers.** You'll be allocated an assigned point of contact who will provide ongoing assistance with reporting and incident escalation.
-
-**Support.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial onboarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
 
 ## Supporting documents and resources
 

--- a/articles/cdsz/cdsz-gs-walled-garden.md
+++ b/articles/cdsz/cdsz-gs-walled-garden.md
@@ -61,7 +61,7 @@ During the provisioning of the Walled Garden service, we'll ask you for some add
 
     These IP addresses are the locations from which you can build and test the environment (for example, offices or end user premises).
 
-The build phase of the Walled Garden environment can take up to 10 working days depending on the complexity of the deployment. When the environment has been fully provisioned, your Customer Success Manager (CSM) will send you the information you need to access it.
+The build phase of the Walled Garden environment can take up to 10 working days depending on the complexity of the deployment. When the environment has been fully provisioned, your Service Delivery Manager (SDM) will send you the information you need to access it.
 
 ## Building your Walled Garden service
 

--- a/articles/cdsz/cdsz-sco.md
+++ b/articles/cdsz/cdsz-sco.md
@@ -94,7 +94,7 @@ You're entitled to claim Service Credits for outages to services that take you o
 
 - We control the deployed versions of technology on the platform. This covers internal platform-supporting technologies, and any technology versions available to you.
 
-  - Internally this includes, but isn’t limited to, the vSphere and ESX versions, and the hardware version of the platform.
+  - Internally this includes, but isn't limited to, the vSphere and ESX versions, and the hardware version of the platform.
 
   - Externally this includes the available versions of the edge gateway and vCloud Director.
 
@@ -120,7 +120,7 @@ We can provide:
 
 For the latest available licences, see the [*UKCloud Pricing Guide*](https://ukcloud.com/wp-content/uploads/2019/07/ukcloud-pricing-guide-11.0-4.pdf).
 
-You can bring your own licensing for Red Hat and certain Microsoft application licensing under Microsoft Mobility using software assurance. You should inform UKCloud via a Service Request if you’re providing your own licensing for a retrospective discount.
+You can bring your own licensing for Red Hat and certain Microsoft application licensing under Microsoft Mobility using software assurance. You should inform UKCloud via a Service Request if you're providing your own licensing for a retrospective discount.
 
 For non-UKCloud issued software, you must obey the licensing requirements of the software provider. This includes being aware of any constraints around using the software in a virtualised environment.
 
@@ -132,7 +132,7 @@ You can use your own images for non-Windows and RHEL services, where licensing s
 
 ### Update services
 
-We make update repositories available for all software for which we provide licensing. We don’t provide software update facilities for non-UKCloud licensed software.
+We make update repositories available for all software for which we provide licensing. We don't provide software update facilities for non-UKCloud licensed software.
 
 ### Anti-virus
 
@@ -180,7 +180,7 @@ Users can access, manage and view the CDSZ service, accessing only those feature
 
 - **UKCloud Portal.** Enables the creation of compute services and subsequently VDCs and edge gateways. The Portal also includes an overview of actual and estimated spend, along with service configuration information. Access to incident and request management is also possible through the Portal.
 
-You cannot access the underlying infrastructure. This includes (but isn’t limited to) the hardware and the vSphere environment.
+You cannot access the underlying infrastructure. This includes (but isn't limited to) the hardware and the vSphere environment.
 
 ## Service reporting
 
@@ -194,21 +194,11 @@ We provide you with monthly bills covering your monthly spend.
 
 ## Customer service
 
-### Customer Success Manager
+**Cloud Architect.** UKCloud Cloud Architects support you during the design of solutions for the cloud platform. UKCloud Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing a CDSZ Walled Garden.
 
-For the first 90 days of the service, you have access to a UKCloud Customer Success Manager (CSM), who will help you with your adoption of the CDSZ service, including finding relevant systems and using UKCloud tools and processes.
+**Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-### Cloud Architects
-
-UKCloud Cloud Architects support you during the design of solutions for the cloud platform. UKCloud Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing a CDSZ Walled Garden.
-
-### Service Delivery Managers
-
-You'll be allocated with a Service Delivery Manager as an assigned point of contact who will provide ongoing assistance with reporting and incident escalation.
-
-### Support
-
-After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [Customer Engagement Factsheet](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [Customer Engagement Factsheet](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
 
 ## Customer responsibilities
 
@@ -228,13 +218,13 @@ You are responsible for:
 
 ## Service provisioning
 
-Within 4 hours of accepting an order (shorter deployment times are typically achieved and can be prioritised upon request), UKCloud will create the customer’s Primary Administrator account and send a Welcome Pack, which includes the URL for the UKCloud Customer Portal, and the Getting Started Guide.
+Within 4 hours of accepting an order (shorter deployment times are typically achieved and can be prioritised upon request), UKCloud will create the customer's Primary Administrator account and send a Welcome Pack, which includes the URL for the UKCloud Customer Portal, and the Getting Started Guide.
 
 Customers will have two options when purchasing a CDSZ service.
 
 - A light-touch design review/self-assessment route for customers with simple implementations, or those who are experienced at designing secure solutions.
 
-- An assurance-wrap style approach with UKCloud’s experienced professionals for more complex implementations or those customers who would like support and guidance when developing their solutions.
+- An assurance-wrap style approach with UKCloud's experienced professionals for more complex implementations or those customers who would like support and guidance when developing their solutions.
 
 Both options require the same submission documentation to enable UKCloud to provision the service.
 
@@ -242,21 +232,19 @@ Deployment time following validation of the assurance document set is 5 days. Th
 
 UKCloud has created several videos, help guides, manuals and FAQs to help train and instruct users so that they are up and running quickly and easily. These are available within the Knowledge Centre.
 
-In addition, you will be assigned a Customer Success Manager (CSM) to provide any assistance required during the first 90 days of the service.
-
 UKCloud also has a large ecosystem of partners who can deliver additional services, such as support and professional services. UKCloud would be pleased to introduce you to the right partner to suit your needs.
 
 ## Service constraints
 
 UKCloud will adhere to the following in terms of maintenance windows:
 
-- *Planned Maintenance* means any pre-planned disruptive maintenance to any of the infrastructure relating to the service. Planned Maintenance activity may result in periods of degradation or loss of availability depending on the nature of the activity required. In such cases, UKCloud shall provide affected customers with at least fourteen (14) days’ notice of the Planned Maintenance.
+- *Planned Maintenance* means any pre-planned disruptive maintenance to any of the infrastructure relating to the service. Planned Maintenance activity may result in periods of degradation or loss of availability depending on the nature of the activity required. In such cases, UKCloud shall provide affected customers with at least fourteen (14) days' notice of the Planned Maintenance.
 
     If during Planned Maintenance there is a loss of availability outside the scope described in the planned maintenance notification to the service, an SLA event will be triggered.
 
 - *Emergency Maintenance* means any urgent maintenance required to prevent or mitigate against any event compromising the infrastructure relating to the service. Whenever possible, UKCloud shall:
 
-    a) provide affected customers with at least six (6) hours’ advance notice and
+    a) provide affected customers with at least six (6) hours' advance notice and
 
     b) carry out the emergency maintenance between the hours of 00:00 and 06:00 (UK local time) Monday to Friday or between the hours of Saturday 00:00 to 06:00 (UK local time) on Monday, (including bank holidays) unless there is an identified and demonstrable immediate risk to customer environment(s). Emergency Maintenance may result in periods of degradation or loss of availability depending on the nature of the activity required.
 

--- a/articles/cloud-storage/cs-sco.md
+++ b/articles/cloud-storage/cs-sco.md
@@ -120,13 +120,11 @@ You can request a migration through a Service Request. Migrations may be between
 
 ## Customer service
 
-**Customer Success Manager (CSM).** For the first 90 days of the service, you have access to a UKCloud Customer Success Manager, who will help you with your adoption of the UKCloud Cloud Storage service, including finding relevant systems and using UKCloud tools and processes.
+**Cloud Architect.** UKCloud Cloud Architects support you during the design of solutions for the cloud platform. UKCloud Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing complex solutions.
 
-**Cloud Architects.** UKCloud Cloud Architects support you during the design of solutions for the cloud platform. UKCloud Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing complex solutions.
+**Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Service Delivery Managers.** You will be allocated with an assigned point of contact who will provide ongoing assistance with reporting and incident escalation.
-
-**Support.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
 
 ## Customer responsibilities
 

--- a/articles/connectivity/conn-faq-janet.md
+++ b/articles/connectivity/conn-faq-janet.md
@@ -45,7 +45,7 @@ Both our Corsham and Farnborough sites have Janet connectivity.
 
 ## How do I get a Janet connection via the UKCloud Assured OFFICIAL security domain?
 
-To place an order for a Janet connection, please raise a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal or speak to your Service Delivery Manager.
+To place an order for a Janet connection, please raise a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal.
 
 ## Can I get a Janet connection via the UKCloud Elevated OFFICIAL security domain?
 

--- a/articles/email/email-faq.md
+++ b/articles/email/email-faq.md
@@ -36,12 +36,6 @@ The service is charged per mailbox per month (or part thereof) which includes 1G
 
 No. As Email and Collaboration has been removed from sale, a free trial is no longer available.
 
-## What happens when my trial comes to an end?
-
-Your Cloud Architect or CSM will contact you when your trial is due to end, either because you have used up all of your credits or because you have reached 30 days (whichever is sooner).
-
-At the end of your trial, you can transition to production or cease the trial.
-
 ## Where is the service hosted?
 
 The service is delivered from two secure UK data centres by UKCloud.
@@ -67,7 +61,7 @@ Yes, you can connect via PSN, Janet and HSCN; via legacy GCF networks including 
 There are several configuration options for using the PSN email relays. These can provide either resiliency across multiple PSN relays or give you an opportunity to just use a single relay (in case of maintenance on the other).
 
 > [!NOTE]
-> For Email services in regions 1, 2, 7 and 8, you’ll need to ensure that the firewall that manages access to the PSN network is set to allow traffic to the IP addresses of both relays on TCP/25.
+> For Email services in regions 1, 2, 7 and 8, you'll need to ensure that the firewall that manages access to the PSN network is set to allow traffic to the IP addresses of both relays on TCP/25.
 
 - Create a local host file entry on your mail system or a DNS entry on your internal DNS server with a name of your choice that is configured with both PSN relay IP addresses.
 
@@ -125,7 +119,7 @@ Yes, there is a minimum charge of 25 mailboxes per month required to set up Emai
 
 ## Is any spam software included?
 
-Yes, mail hygiene is provided via Cisco IronPort® for internet-facing solutions, providing protection against spam and malware. In addition, there is a centralised mail scanning solution within the PSN; combined with the fact that as a restricted network, spam is much less of an issue than with internet connections.
+Yes, mail hygiene is provided via Cisco IronPort&reg; for internet-facing solutions, providing protection against spam and malware. In addition, there is a centralised mail scanning solution within the PSN; combined with the fact that as a restricted network, spam is much less of an issue than with internet connections.
 
 ## Is there a mail archive solution?
 
@@ -145,7 +139,7 @@ Briefcase is a document storing and sharing function that allows users to upload
 
 ## What are the default Class of Service settings?
 
-A Class of Service exists for each e-mail domain and defines the features, access privileges and default preferences that a new user account receives. For existing accounts, if a setting has been specified within the client’s Preferences tab, it will take precedence; otherwise the Class of Service setting will be applied. All new accounts will inherit the settings from the Class of Service. For information about the default Class of Service settings, or to request that a setting is changed from the default, raise a Service Request via the My Calls section of the UKCloud Portal.
+A Class of Service exists for each e-mail domain and defines the features, access privileges and default preferences that a new user account receives. For existing accounts, if a setting has been specified within the client's Preferences tab, it will take precedence; otherwise the Class of Service setting will be applied. All new accounts will inherit the settings from the Class of Service. For information about the default Class of Service settings, or to request that a setting is changed from the default, raise a Service Request via the My Calls section of the UKCloud Portal.
 
 ## How long does it take to get the solution up and running?
 

--- a/articles/email/email-how-setup-iphone.md
+++ b/articles/email/email-how-setup-iphone.md
@@ -67,7 +67,7 @@ For more information about ActiveSync, go to <https://en.wikipedia.org/wiki/Act
   
 6. Click **Next**.
 
-7. Enter your server details as supplied by your UKCloud Customer Success Manager.
+7. Enter your server details as supplied by your UKCloud Service Delivery Manager (SDM).
 
 8. Synchronise **Mail**, **Contacts**, and/or **Calendars** as you prefer by setting the appropriate sliders to on.
 

--- a/articles/gpu/gpu-sco.md
+++ b/articles/gpu/gpu-sco.md
@@ -162,13 +162,11 @@ You cannot access the underlying infrastructure. This includes (but isn't limite
 
 ## Customer service
 
-**Customer Success Manager (CSM).** For the first 90 days of the service, you have access to a UKCloud CSM. They will help you with your adoption of the UKCloud Cloud GPU service, including finding relevant systems and using UKCloud tools and processes.
+**Cloud Architect.** UKCloud Cloud Architects support you during the design of solutions for the cloud platform. They are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing complex solutions, such as those using HybridConnect or a Walled Garden.
 
-**Cloud Architects.** UKCloud Cloud Architects support you during the design of solutions for the cloud platform. They are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing complex solutions, such as those using HybridConnect or a Walled Garden.
+**Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Service Delivery Manager.** After the initial 90 days, you'll be allocated with an assigned point of contact who will provide ongoing assistance with reporting and incident escalation.
-
-**Support.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is outlined in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is outlined in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
 
 ## Customer responsibilities
 
@@ -178,11 +176,11 @@ Alongside the responsibilities outlined in the [*UKCloud for VMware Service Scop
 
 Outside of the creation of your UKCloud for VMware resources needed to support your GPU service, customers can request the addition of GPU capabilities in GPU-enabled zones via the service request option, and the service will be available within 10 working days.
 
-If you request access to Cloud GPU resources for existing VMs that are not in a GPU-enabled zone, our CSMs will work with you to configure new UKCloud for VMware, High Performance Compute or UKCloud for OpenStack services in the correct zone.
+If you request access to Cloud GPU resources for existing VMs that are not in a GPU-enabled zone, our SDMs will work with you to configure new UKCloud for VMware, High Performance Compute or UKCloud for OpenStack services in the correct zone.
 
 UKCloud has created several videos, helpful guides, manuals and FAQs to help train and instruct users so that they are up and running quickly and easily. These are available within the [Knowledge Centre](https://docs.ukcloud.com/).
 
-As previously mentioned, you will be assigned a Customer Success Manager (CSM) to provide any assistance required during the first 90 days of the service.
+As previously mentioned, your Service Delivery Manager (SDM) will provide any assistance during the provisioning of the service.
 
 UKCloud also has a large ecosystem of partners who can deliver additional services, such as support and professional services. UKCloud would be pleased to introduce you to the right partner to suit your needs.
 

--- a/articles/hpc/hpc-ref-overview.md
+++ b/articles/hpc/hpc-ref-overview.md
@@ -77,7 +77,7 @@ High Performance Compute includes as standard:
 
 - DDoS-protected internet
 
-- Personalised support via Customer Success Managers, Service Delivery Managers and a telephone support desk
+- Personalised support via Service Delivery Managers and a telephone support desk
 
 To model a total cost of ownership, you may also want to consider additional elements, such as connectivity, and service options, such as cloud enablement and cross-domain services.
 

--- a/articles/openstack/ostack-faq.md
+++ b/articles/openstack/ostack-faq.md
@@ -436,9 +436,9 @@ At the time of order, you can specify which of our two UK data centres you'd lik
 
 We offer a 30-day free trial so that you can test and evaluate our service without commitment. Your trial provides you with a live environment on the UKCloud platform to test our services and check whether they're suited to your needs.
 
-Before your trial, a Cloud Architect will engage with you to identify the goals you\'re working towards, to help ensure that your trial meets those goals.
+Before your trial, a Cloud Architect will engage with you to identify the goals you're working towards, to help ensure that your trial meets those goals.
 
-Throughout the trial period, a Customer Success Manager (CSM) will provide support for any issues you may encounter or questions you may have.
+Throughout the trial period, a Service Delivery Manager (SDM) will provide support for any issues you may encounter or questions you may have.
 
 At the end of your free trial, you can seamlessly move to a billed service, leveraging any of the work you've already completed in the live trial environment.
 

--- a/articles/oracle/orcl-gs.md
+++ b/articles/oracle/orcl-gs.md
@@ -72,7 +72,7 @@ UKCloud for Oracle Software does not include Oracle licensing but, because the p
 
 UKCloud ensures that hard partitioning is in place in all customer guest VMs in order to conform to Oracle licensing policies. When you create or modify a VM, automatic CPU pinning ensures that the VM won't use any CPUs other than the ones specifically pinned to the VM's vCPUs.
 
-If you have any questions about Oracle licensing, contact your Cloud Architect, Customer Success Manager or Service Delivery Manager.
+If you have any questions about Oracle licensing, contact your Cloud Architect or Service Delivery Manager (SDM).
 
 If you require assistance building out your Oracle solution, we can put you in contact with one or our partners who specialises in Oracle technologies.
 
@@ -86,7 +86,7 @@ The management of your Oracle estate is split between Oracle Enterprise Manager 
 
 ![UKCloud for Oracle Software architecture](images/orcl-architecture.png)
 
-When you first purchase UKCloud for Oracle Software, your Customer Success Manager (CSM) creates an Oracle tenant to act as a top‑level container for your Oracle VMs. As your estate grows, you can add more tenants to logically organise your resources.
+When you first purchase UKCloud for Oracle Software, your SDM creates an Oracle tenant to act as a top‑level container for your Oracle VMs. As your estate grows, you can add more tenants to logically organise your resources.
 
 Within your Oracle tenant you can create the VMs that comprise your Oracle applications.
 
@@ -353,8 +353,6 @@ This section provides a glossary of terms specific to UKCloud for Oracle Softwar
 **Assured OFFICIAL**&nbsp;&nbsp;A security domain on the UKCloud platform that provides access to public networks, such as the internet, PSN, HSCN or Janet.
 
 **Cloud Console**&nbsp;&nbsp;System management software from Oracle that delivers centralized monitoring, administration, and life-cycle management functionality for the complete IT infrastructure, including systems running Oracle and non-Oracle technologies.
-
-**Customer Success Manager (CSM)**&nbsp;&nbsp;A UKCloud Customer Services role aimed at providing you with any assistance you require during onboarding and the first 90 days of using a UKCloud service.
 
 **edge gateway**&nbsp;&nbsp;A virtual router that provides VDC network services such as DHCP, firewall, NAT, static routing, VPN and load balancing.
 

--- a/articles/oracle/orcl-sco.md
+++ b/articles/oracle/orcl-sco.md
@@ -140,7 +140,7 @@ As the underlying platform is powered by OVM technology, you can either transfer
 
 **Internet-facing solutions.** You are provided with 2 usable public IP addresses, but you can ask for additional public IP addresses by raising a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal. We reserve the right to decline the request if you have spare capacity in your existing deployment.
 
-**PSN-facing solutions.** You should raise a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal or contact your Customer Success Manager (CSM) to be assigned your IP address. This solution also comes with shared bandwidth (uncapped).
+**PSN-facing solutions.** You should raise a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal to be assigned your IP address. This solution also comes with shared bandwidth (uncapped).
 
 **Janet and HSCN solutions.** You have one usable IP address, but you can request additional IP addresses by raising a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal.
 
@@ -192,13 +192,11 @@ UKCloud do not currently provide migration services, however customers are free 
 
 ## Customer service
 
-**Customer Success Manager (CSM).** For the first 90 days of the service, you have access to a UKCloud CSM who will help you with your adoption of the UKCloud UKCloud for Oracle Software service. This includes finding relevant systems and how to use UKCloud tools and processes.
+**Cloud Architect.** UKCloud Cloud Architects support you during the design of solutions for the cloud platform. UKCloud Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing Oracle solutions.
 
-**Cloud Architects.** UKCloud Cloud Architects support you during the design of solutions for the cloud platform. UKCloud Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing Oracle solutions.
+**Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Service Delivery Managers.** You will be allocated with an assigned point of contact who will provide ongoing assistance with reporting and incident escalation.
-
-**Support.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
 
 ## Customer responsibilities
 
@@ -220,7 +218,7 @@ UKCloud and Infomentum will provision the Oracle Tenant environment. UKCloud wil
 
 UKCloud has created several videos, help guides, manuals and FAQs to help train and instruct users so that they are up and running quickly and easily. These are available within the [*UKCloud Knowledge Centre*](https://docs.ukcloud.com/).
 
-In addition, you will be assigned a Customer Success Manager (CSM) to provide any assistance required during the first 90 days of the service. UKCloud also has a large ecosystem of partners who can deliver additional services, such as support and professional services. UKCloud would be pleased to introduce you to the right partner to suit your needs.
+UKCloud also has a large ecosystem of partners who can deliver additional services, such as support and professional services. UKCloud would be pleased to introduce you to the right partner to suit your needs.
 
 ## Service constraints
 

--- a/articles/other/other-faq-eps.md
+++ b/articles/other/other-faq-eps.md
@@ -91,7 +91,7 @@ Yes. We offer a 30-day free trial for many of our services. Your trial provides 
 
 You can request a trial via the UKCloud website: https://www.UKCloud.com/free-trial-sign-up and accept the trial terms and conditions. Your environment will then be set up and you will be given trial credits to the equivalent of £500.
 
-You will be contacted by your Cloud Architect or CSM when your trial is due to end, either because you have run out of credits or reached 30 days (whichever is sooner). At the end of your trial, you have the option to transition to production or cease the trial.
+You will be contacted by your Cloud Architect or Service Delivery Manager (SDM) when your trial is due to end, either because you have run out of credits or reached 30 days (whichever is sooner). At the end of your trial, you have the option to transition to production or cease the trial.
 
 ## Feedback
 

--- a/articles/other/other-ref-glossary.md
+++ b/articles/other/other-ref-glossary.md
@@ -137,19 +137,19 @@ For more information, see the [Cross Domain Security Zone service definition](..
 
 ### Customer Success Manager (CSM)
 
-A UKCloud Customer Services role aimed at providing you with any assistance you may require during onboarding and the first 90 days of using a UKCloud service.
+*See:* [Service Delivery Manager](#service-delivery-manager)
 
 ## D
 
 ### Data centre interconnect (DCI)
 
-A UKCloud connectivity service that enables self-designed and managed disaster recovery solutions, or increased connectivity resilience, by using UKCloud’s assured connections between our sites.
+A UKCloud connectivity service that enables self-designed and managed disaster recovery solutions, or increased connectivity resilience, by using UKCloud's assured connections between our sites.
 
 *See also:* [Assured inter-data centre connectivity](#assured-inter-data-centre-connectivity), [Dedicated inter-data centre connectivity](#dedicated-inter-data-centre-connectivity)
 
 ### Data Transfer Facility (DTF)
 
-A UKCloud enablement service that enables you to use the secure network connections at our Farnborough site to manage systems or transfer data into or out of your environments. This service is useful if you don’t have enough network bandwidth or are waiting for appropriately accredited connectivity to be installed.
+A UKCloud enablement service that enables you to use the secure network connections at our Farnborough site to manage systems or transfer data into or out of your environments. This service is useful if you don't have enough network bandwidth or are waiting for appropriately accredited connectivity to be installed.
 
 *See also:* [Mass Transfer Facility (MTF)](#mass-transfer-facility-mtf)
 
@@ -237,7 +237,7 @@ For more information, see the [UKCloud Big Data & Hadoop service proposition](ht
 
 ### Health and Social Care Network (HSCN)
 
-A government network designed to provide a solution for hospitals, medical centres and GPs to collaborate and access services over a secure, high speed network. One of UKCloud’s connectivity options, available on the Assured OFFICIAL security domain.
+A government network designed to provide a solution for hospitals, medical centres and GPs to collaborate and access services over a secure, high speed network. One of UKCloud's connectivity options, available on the Assured OFFICIAL security domain.
 
 For more information, see the [HSCN FAQs](../connectivity/conn-faq-hscn.md).
 
@@ -281,7 +281,7 @@ A customer provisioned compute resource within OpenStack, similar to the virtual
 
 ### Janet
 
-The UK's research and education network, used by education organisations and research councils. One of UKCloud’s connectivity options, available on the Assured OFFICIAL security domain.
+The UK's research and education network, used by education organisations and research councils. One of UKCloud's connectivity options, available on the Assured OFFICIAL security domain.
 
 For more information, see the [Janet connectivity FAQs](../connectivity/conn-faq-janet.md).
 
@@ -301,7 +301,7 @@ For more information, see the [Jumpstart FAQs](../other/other-faq-jumpstart.md).
 
 ### Knowledge Centre
 
-UKCloud’s repository of articles created in collaboration with subject matter experts to provide information about how to use our products and services.
+UKCloud's repository of articles created in collaboration with subject matter experts to provide information about how to use our products and services.
 
 *See:* <https://docs.ukcloud.com/>
 
@@ -335,7 +335,7 @@ For more information, see the [Moogsoft AIOps from UKCloud service definition](.
 
 ### Multi-Cloud Backup Storage
 
-A UKCloud IaaS service that provides a backup target that is accessible from every cloud within UKCloud's multi-cloud platform, based on Dell EMC's Data Domain Boost™ (DD Boost) technology, enabling open-source backup applications to utilise the backup service as a target. You can also use Multi-Cloud Backup Storage as a remote backup target for your on-premises data.
+A UKCloud IaaS service that provides a backup target that is accessible from every cloud within UKCloud's multi-cloud platform, based on Dell EMC's Data Domain Boost&trade; (DD Boost) technology, enabling open-source backup applications to utilise the backup service as a target. You can also use Multi-Cloud Backup Storage as a remote backup target for your on-premises data.
 
 For more information, see the [Multi-Cloud Backup Storage service definition](../other/other-sd-mcbs.md).
 
@@ -431,7 +431,7 @@ Note the difference between Private Cloud, which is a single-tenant environment 
 
 ### Private Cloud for Oracle Software
 
-A UKCloud IaaS service that enables you to have private implementations of Oracle's Engineered Systems within UKCloud’s assured, sovereign data centres, Crown Hosting Data Centres or even on-premise.
+A UKCloud IaaS service that enables you to have private implementations of Oracle's Engineered Systems within UKCloud's assured, sovereign data centres, Crown Hosting Data Centres or even on-premise.
 
 For more information, see the [Private Cloud for Oracle Software service definition](../private-cloud/prc-sd-orcl.md).
 
@@ -449,7 +449,7 @@ For more information, see [Protective Monitoring from UKCloud](../other/other-re
 
 ### Public Services Network (PSN)
 
-A government network, used by central, local and devolved government organisations. One of UKCloud’s connectivity options, available on the Assured OFFICIAL and Elevated OFFICIAL security domains.
+A government network, used by central, local and devolved government organisations. One of UKCloud's connectivity options, available on the Assured OFFICIAL and Elevated OFFICIAL security domains.
 
 For more information, see the [Public Services Network (PSN) FAQs](../connectivity/conn-faq-psn.md).
 
@@ -467,7 +467,7 @@ A physically segregated part of the UKCloud platform with its own power infrastr
 
 ### Restricted LAN Interconnect (RLI)
 
-A high-security network for defence and industry partners. One of UKCloud’s connectivity options. Connection to RLI is subject to extensive vetting and approval from the MOD. Contact one of our Cloud Architects for more information about how to connect to RLI.
+A high-security network for defence and industry partners. One of UKCloud's connectivity options. Connection to RLI is subject to extensive vetting and approval from the MOD. Contact one of our Cloud Architects for more information about how to connect to RLI.
 
 ## S
 
@@ -481,13 +481,13 @@ For more information, see the [Secure Remote Access service definition](../sra/s
 
 ### Service Credits
 
-A compensation scheme whereby if we fall short of our service level agreement, we’ll compensate you with credits that you redeem them against UKCloud services.
+A compensation scheme whereby if we fall short of our service level agreement, we'll compensate you with credits that you redeem them against UKCloud services.
 
 *See also:* [Cloud Credits](#cloud-credits)
 
 ### Service Delivery Manager
 
-A UKCloud Customer Services role aimed at providing you with an assigned point of contact after the first 90 days with a service.
+A UKCloud Customer Services role aimed at providing you with an assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
 ### Site
 
@@ -547,7 +547,7 @@ For more information, see the [Transition Services service definition](../transi
 
 ### UKCloud for Microsoft Azure
 
-A UKCloud IaaS service that harnesses the innovation of Microsoft’s Azure platform delivered from within our award-winning government-grade multi-cloud environment.
+A UKCloud IaaS service that harnesses the innovation of Microsoft's Azure platform delivered from within our award-winning government-grade multi-cloud environment.
 
 For more information, see the [UKCloud for Microsoft Azure service definition](../azure/azs-sd.md).
 
@@ -607,7 +607,7 @@ A container for VMs, where each VM has the same workload characteristics and acc
 
 ### Virtual machine (VM)
 
-Software that emulates the functionality of a physical computer, running an operating system and applications. Customers can define a VM’s resource requirements and the UKCloud platform optimises its placement to ensure it receives the requested resources.
+Software that emulates the functionality of a physical computer, running an operating system and applications. Customers can define a VM's resource requirements and the UKCloud platform optimises its placement to ensure it receives the requested resources.
 
 ### VMware
 

--- a/articles/other/other-ref-offboarding.md
+++ b/articles/other/other-ref-offboarding.md
@@ -36,9 +36,9 @@ If you want to terminate your whole account with UKCloud, you must raise separat
 
 ## Customer responsibilities
 
-- When you decide to terminate a service, you should first contact your Service Delivery Manager. Your Service Delivery Manager will help you to determine the relevant environment details for termination and the Effective Date of Termination.
+- When you decide to terminate a service, you should first contact your Service Delivery Manager (SDM). Your SDM will help you to determine the relevant environment details for termination and the Effective Date of Termination.
 
-- After speaking to your Service Delivery Manager, an administrator of your Portal account must raise a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal, following the relevant prompts for information to enable our support team to action the request as quickly as possible.
+- After speaking to your SDM, an administrator of your Portal account must raise a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal, following the relevant prompts for information to enable our support team to action the request as quickly as possible.
 
     > [!NOTE]
     > If you do not raise a Service Request to initiate a formal termination of service, your environment may not be completely decommissioned and you may end up still being charged for objects remaining on the platform.

--- a/articles/other/other-sco-free-trials.md
+++ b/articles/other/other-sco-free-trials.md
@@ -25,7 +25,7 @@ Free trials provide you with a live environment on the UKCloud platform to test 
 
 Prior to your trial, you will be engaged by a Cloud Architect to identify the goals you are working towards, and to ensure that your trial meets them.
 
-Throughout the trial period, we will assign you a Customer Success Manager (CSM), who will provide support for any issues you may encounter or questions you may have.
+Throughout the trial period, we will assign you a Service Delivery Manager (SDM), who will provide support for any issues you may encounter or questions you may have.
 
 At the end of your free trial, you can seamlessly move to a billed service, leveraging any of the work you have already completed in the live trial environment.
 
@@ -83,11 +83,11 @@ During your trial:
 
 - Use your credits for any eligible service within your environment within 30 days, unless stated differently in the Service Scope
 
-- Contact your CSM with any issues or questions
+- Contact your SDM with any issues or questions
 
 Ending your trial
 
-- You will be contacted by your Cloud Architect or CSM when your trial is due to end, either because you have run out of credits or reached 30 days (whichever is sooner)
+- You will be contacted by your Cloud Architect or SDM when your trial is due to end, either because you have run out of credits or reached 30 days (whichever is sooner)
 
 - You have the option to transition to production or cease the trial
 

--- a/articles/portal/ptl-gs.md
+++ b/articles/portal/ptl-gs.md
@@ -45,7 +45,7 @@ This Getting Started Guide is intended for any user with access to the Portal.
 
 ## Before you begin
 
-You should have received your Portal login credentials from your Portal administrator. If you're the Portal administrator, your Customer Success Manager (CSM) will have provided you with your login credentials.
+You should have received your Portal login credentials from your Portal administrator. If you're the Portal administrator, your Service Delivery Manager (SDM) will have provided you with your login credentials.
 
 The Portal works with Google Chrome, Microsoft Edge and Mozilla Firefox.
 
@@ -57,7 +57,7 @@ The first thing you need to do is log in.
 
     - **Assured OFFICIAL:** <https://portal.ukcloud.com>
 
-    - **Elevated OFFICIAL:** Contact your Portal administrator or Customer Success Manager (CSM)
+    - **Elevated OFFICIAL:** Contact your Portal administrator or SDM
 
 2. On the *Log in* page, enter your credentials and click **Sign in**.
 
@@ -66,7 +66,7 @@ The first thing you need to do is log in.
     > [!TIP]
     > If you've forgotten your password, click the **Forgotten password?** link to request a password reset.
 
-    If this is the first time you've logged in, use the temporary password you were given by your Portal administrator or CSM. You'll be prompted to change this temporary password.
+    If this is the first time you've logged in, use the temporary password you were given by your Portal administrator or SDM. You'll be prompted to change this temporary password.
 
     > [!NOTE]
     > If you incorrectly enter your password three times, you'll be prompted to enter a captcha code until you successfully log in. If you incorrectly enter the captcha code or your password another three times, a seventh unsuccessful login attempt will result in your account being locked. You'll need to contact your Portal administrator to unlock your account.
@@ -234,11 +234,6 @@ Within the UKCloud VMware environment there are two types of account:
 ### compute service
 
 A UKCloud for VMware top-level container within a customer account that includes a vCloud Director organization and its VDCs, catalogs, users and resources.
-
-### Customer Success Manager (CSM)
-
-A UKCloud Customer Services role aimed at providing you with any assistance you require during onboarding and the first 90 days of using
-a UKCloud service.
 
 ### Knowledge Centre
 

--- a/articles/portal/ptl-how-raise-escalate-service-request.md
+++ b/articles/portal/ptl-how-raise-escalate-service-request.md
@@ -61,7 +61,7 @@ Methods for contacting The UKCloud team are as follows:
 
 - UKCloud Portal (Assured) - <https://portal.ukcloud.com/>
 
-- UKCloud Portal (Elevated) - Contact your Portal administrator or Customer Success Manager (CSM)
+- UKCloud Portal (Elevated) - Contact your Portal administrator or Service Delivery Manager (SDM)
 
 - Telephone - 01252 303 300 (select option 2)
 
@@ -121,7 +121,7 @@ During a Major Incident, updates are published to the Service Status page: <http
 
 ## Escalation
 
-For onboarding issues, contact your allocated Customer Success Manager (CSM).
+For onboarding issues, contact your allocated SDM.
 
 To escalate an incident or service request, contact the Support Team (by phone in the first instance):
 
@@ -129,7 +129,7 @@ To escalate an incident or service request, contact the Support Team (by phone i
 
 - Email: <escalations@ukcloud.com> (monitored 24 x 7)
 
-For wider service issues, contact your Service Delivery Manager during standard office hours.
+For wider service issues, contact your SDM during standard office hours.
 
 ## Feedback
 

--- a/articles/portal/ptl-ref-multiple-accounts.md
+++ b/articles/portal/ptl-ref-multiple-accounts.md
@@ -81,7 +81,7 @@ There are two options that you can choose from to manage your projects and end c
 
 ## Creating multiple accounts
 
-When you bring a new workload to UKCloud, your Service Delivery Manager or Customer Success Manager (CSM) will discuss your requirements and whether you want to create an additional account. If you decide that an additional account is best for your setup, UKCloud will create it for you. Once the additional account is created, the Portal administrator for the account can then add existing UKCloud Portal users to the account by raising a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal or add new users to the UKCloud Portal onto the new account, which the administrator can add themselves.
+When you bring a new workload to UKCloud, your Service Delivery Manager (SDM) will discuss your requirements and whether you want to create an additional account. If you decide that an additional account is best for your setup, UKCloud will create it for you. Once the additional account is created, the Portal administrator for the account can then add existing UKCloud Portal users to the account by raising a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal or add new users to the UKCloud Portal onto the new account, which the administrator can add themselves.
 
 ## Related articles
 

--- a/articles/private-cloud/prc-sco-orcl.md
+++ b/articles/private-cloud/prc-sco-orcl.md
@@ -119,7 +119,7 @@ As your service needs grow, we'll work with you to coordinate the installation o
 
 ### Your UKCloud Hosted responsibilities
 
-- If your engineers will require access to manage and maintain the hardware you will need to ensure they are booked in to visit UKCloud DCs. This can be done by raising a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal. Note that due to the secure nature of the site, at least 24 hours’ notice is required. Engineers must be escorted and this is charged at a [SFIA](https://ukcloud.com/wp-content/uploads/2019/06/ukc-gen-759-ukcloud-g-cloud-11-standard-rate-card-and-definitions.pdf) day rate.
+- If your engineers will require access to manage and maintain the hardware you will need to ensure they are booked in to visit UKCloud DCs. This can be done by raising a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal. Note that due to the secure nature of the site, at least 24 hours' notice is required. Engineers must be escorted and this is charged at a [SFIA](https://ukcloud.com/wp-content/uploads/2019/06/ukc-gen-759-ukcloud-g-cloud-11-standard-rate-card-and-definitions.pdf) day rate.
 
 ### Your CHDC Hosted responsibilities
 
@@ -237,7 +237,7 @@ As per All-Inclusive plus:
 
 - Providing you with visibility of capacity utilisation to ensure capacity planning can be effectively performed
 
-- Your assigned Service Delivery Manager will attend any required service reviews and project progress calls that you need
+- Your assigned Service Delivery Manager (SDM) will attend any required service reviews and project progress calls that you need
 
 - Notifying you of any maintenance windows and agreeing a suitable time to implement
 
@@ -307,7 +307,7 @@ SLA excludes:
 
 ## To progress further
 
-For further information, contact your Service Delivery Manager to request more information or to place an order.
+Contact your SDM to request more information or to place an order.
 
 ## Feedback
 

--- a/articles/private-cloud/prc-sco-storage.md
+++ b/articles/private-cloud/prc-sco-storage.md
@@ -201,7 +201,7 @@ We will not supply you with root access to your hardware as your hardware will b
 
 ## To progress further
 
-For further information, please see the [*Private Cloud for Storage Service Definition*](prc-sd-storage.md) and contact your Service Delivery Manager to request more information or to place an order.
+For more information, see the [*Private Cloud for Storage Service Definition*](prc-sd-storage.md). Contact your Service Delivery Manager to request further information or to place an order.
 
 ## Feedback
 

--- a/articles/private-cloud/prc-sco.md
+++ b/articles/private-cloud/prc-sco.md
@@ -167,7 +167,7 @@ We cannot be responsible for any service affecting issues resulting from non-esc
 
 - Providing you with visibility of capacity utilisation to ensure capacity planning can be effectively performed
 
-- Your assigned Service Delivery Manager will attend any required service reviews and project progress calls that you need
+- Your assigned Service Delivery Manager (SDM) will attend any required service reviews and project progress calls that you need
 
 - Notifying you of any maintenance windows and agreeing a suitable time to implement
 
@@ -219,7 +219,7 @@ We cannot be responsible for any service affecting issues resulting from non-esc
 
 ## To progress further
 
-For further information, contact your Service Delivery Manager to request more information or to place an order.
+Contact your SDM to request more information or to place an order.
 
 ## Feedback
 

--- a/articles/sra/sra-sco.md
+++ b/articles/sra/sra-sco.md
@@ -35,7 +35,7 @@ Customers will have two options when purchasing an SRA service:
 
 - A light-touch design review/self-assessment route for customers with simple implementations, or those who are experienced at designing secure solutions.
 
-- An assurance-wrap style approach with UKCloud’s experienced professionals for more complex implementations or those customers who would like support and guidance when developing their solutions.
+- An assurance-wrap style approach with UKCloud's experienced professionals for more complex implementations or those customers who would like support and guidance when developing their solutions.
 
 Both options require the same submission documentation to enable UKCloud to provision the service. This is documented in [*UKCloud Cross Domain Security Zone application process*](../cdsz/cdsz-ref-application-process.md).
 
@@ -101,7 +101,7 @@ You're entitled to claim Service Credits for outages to services that take you o
 
 - We control the deployed versions of technology on the platform. This covers internal platform-supporting technologies, and any technology versions available to you.
 
-  - Internally this includes, but isn’t limited to, the vSphere and ESX versions, and the hardware version of the platform.
+  - Internally this includes, but isn't limited to, the vSphere and ESX versions, and the hardware version of the platform.
 
   - Externally this includes the available versions of the edge gateway and vCloud Director.
 
@@ -127,7 +127,7 @@ We can provide:
 
 For the latest available licences, see the [*UKCloud Pricing Guide*](https://ukcloud.com/wp-content/uploads/2019/07/ukcloud-pricing-guide-11.0-4.pdf).
 
-You can bring your own licensing for Red Hat and certain Microsoft application licensing under Microsoft Mobility using software assurance. You should inform UKCloud via a Service Request if you’re providing your own licensing for a retrospective discount.
+You can bring your own licensing for Red Hat and certain Microsoft application licensing under Microsoft Mobility using software assurance. You should inform UKCloud via a Service Request if you're providing your own licensing for a retrospective discount.
 
 For non-UKCloud issued software, you must obey the licensing requirements of the software provider. This includes being aware of any constraints around using the software in a virtualised environment.
 
@@ -139,7 +139,7 @@ You can use your own images for non-Windows and RHEL services, where licensing s
 
 ### Update services
 
-We make update repositories available for all software for which we provide licensing. We don’t provide software update facilities for non-UKCloud licensed software.
+We make update repositories available for all software for which we provide licensing. We don't provide software update facilities for non-UKCloud licensed software.
 
 ### Anti-virus
 
@@ -187,7 +187,7 @@ Users can access, manage and view the SRA service, accessing only those features
 
 - **UKCloud Portal.** Enables the creation of compute services and subsequently VDCs and edge gateways. The Portal also includes an overview of actual and estimated spend, along with service configuration information. Access to incident and request management is also possible through the Portal.
 
-You cannot access the underlying infrastructure. This includes (but isn’t limited to) the hardware and the vSphere environment.
+You cannot access the underlying infrastructure. This includes (but isn't limited to) the hardware and the vSphere environment.
 
 ## Service reporting
 
@@ -201,21 +201,11 @@ We provide you with monthly bills covering your monthly spend.
 
 ## Customer service
 
-### Customer Success Manager
+**Cloud Architect.** UKCloud Cloud Architects support you during the design of solutions for the cloud platform. UKCloud Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing an SRA walled garden.
 
-For the first 90 days of the service, you have access to a UKCloud Customer Success Manager (CSM), who will help you with your adoption of the SRA service, including finding relevant systems and using UKCloud tools and processes.
+**Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-### Cloud Architects
-
-UKCloud Cloud Architects support you during the design of solutions for the cloud platform. UKCloud Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing an SRA walled garden.
-
-### Service Delivery Managers
-
-You'll be allocated with a Service Delivery Manager as an assigned point of contact who will provide ongoing assistance with reporting and incident escalation.
-
-### Support
-
-After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [Customer Engagement Factsheet](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [Customer Engagement Factsheet](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
 
 ## Customer responsibilities
 
@@ -241,13 +231,13 @@ You are responsible for:
 
 ## Service provisioning
 
-Within 4 hours of accepting an order (shorter deployment times are typically achieved and can be prioritised upon request), UKCloud will create the customer’s Primary Administrator account and send a Welcome Pack, which includes the URL for the UKCloud Customer Portal, and the Getting Started Guide.
+Within 4 hours of accepting an order (shorter deployment times are typically achieved and can be prioritised upon request), UKCloud will create the customer's Primary Administrator account and send a Welcome Pack, which includes the URL for the UKCloud Customer Portal, and the Getting Started Guide.
 
 Customers will have two assessment options when purchasing an SRA service.
 
 - A light-touch design review/self-assessment route for customers with simple implementations, or those who are experienced at designing secure solutions.
 
-- An assurance-wrap style approach with UKCloud’s experienced professionals for more complex implementations or those customers who would like support and guidance when developing their solutions.
+- An assurance-wrap style approach with UKCloud's experienced professionals for more complex implementations or those customers who would like support and guidance when developing their solutions.
 
 Both options require the same submission documentation to enable UKCloud to provision the service.
 
@@ -255,21 +245,19 @@ Deployment time following validation of the assurance document set is 5 days. Th
 
 UKCloud has created several videos, help guides, manuals and FAQs to help train and instruct users so that they are up and running quickly and easily. These are available within the Knowledge Centre.
 
-In addition, you will be assigned a Customer Success Manager (CSM) to provide any assistance required during the first 90 days of the service.
-
 UKCloud also has a large ecosystem of partners who can deliver additional services, such as support and professional services. UKCloud would be pleased to introduce you to the right partner to suit your needs.
 
 ## Service constraints
 
 UKCloud will adhere to the following in terms of maintenance windows:
 
-- *Planned Maintenance* means any pre-planned disruptive maintenance to any of the infrastructure relating to the service. Planned Maintenance activity may result in periods of degradation or loss of availability depending on the nature of the activity required. In such cases, UKCloud shall provide affected customers with at least fourteen (14) days’ notice of the Planned Maintenance.
+- *Planned Maintenance* means any pre-planned disruptive maintenance to any of the infrastructure relating to the service. Planned Maintenance activity may result in periods of degradation or loss of availability depending on the nature of the activity required. In such cases, UKCloud shall provide affected customers with at least fourteen (14) days' notice of the Planned Maintenance.
 
     If during Planned Maintenance there is a loss of availability outside the scope described in the planned maintenance notification to the service, an SLA event will be triggered.
 
 - *Emergency Maintenance* means any urgent maintenance required to prevent or mitigate against any event compromising the infrastructure relating to the service. Whenever possible, UKCloud shall:
 
-    a) provide affected customers with at least six (6) hours’ advance notice and
+    a) provide affected customers with at least six (6) hours' advance notice and
 
     b) carry out the emergency maintenance between the hours of 00:00 and 06:00 (UK local time) Monday to Friday or between the hours of Saturday 00:00 to 06:00 (UK local time) on Monday, (including bank holidays) unless there is an identified and demonstrable immediate risk to customer environment(s). Emergency Maintenance may result in periods of degradation or loss of availability depending on the nature of the activity required.
 

--- a/articles/vmware/vmw-faq.md
+++ b/articles/vmware/vmw-faq.md
@@ -463,7 +463,7 @@ You can request a trial via the UKCloud website: <https://www.ukcloud.com/free-t
 
 ### What do I do when my trial comes to an end?
 
-You will be contacted by your Cloud Architect or CSM when your trial is due to end, either because you have run out of credits or reached 30 days (whichever is sooner).
+You will be contacted by your Cloud Architect or Service Delivery Manager (SDM) when your trial is due to end, either because you have run out of credits or reached 30 days (whichever is sooner).
 
 At the end of your trial, you have the option to transition to production or cease the trial.
 

--- a/articles/vmware/vmw-gs.md
+++ b/articles/vmware/vmw-gs.md
@@ -30,7 +30,7 @@ To complete the steps in this guide you must have access to the UKCloud Portal a
 
 ## Before you begin
 
-You should have received your UKCloud Portal login credentials from your Customer Success Manager (CSM).
+You should have received your UKCloud Portal login credentials from your Service Delivery Manager (SDM).
 
 ## Introductions to UKCloud for VMware
 
@@ -50,7 +50,7 @@ The first thing you need to do to get started with UKCloud for VMware is to log 
 
     - **Assured OFFICIAL:** <https://portal.ukcloud.com>
 
-    - **Elevated OFFICIAL:** Contact your Portal administrator or Customer Success Manager (CSM)
+    - **Elevated OFFICIAL:** Contact your Portal administrator or SDM
 
 2. On the *Log in* page, enter your credentials and click **Sign in**.
 
@@ -59,7 +59,7 @@ The first thing you need to do to get started with UKCloud for VMware is to log 
     > [!TIP]
     > If you've forgotten your password, click the **Forgotten password?** link to request a password reset.
 
-    If this is the first time you've logged in, use the temporary password you were given by your Portal administrator or CSM. You'll be prompted to change this temporary password.
+    If this is the first time you've logged in, use the temporary password you were given by your Portal administrator or SDM. You'll be prompted to change this temporary password.
 
 3. If your Portal administrator has enabled two-factor authentication (2FA), you'll be prompted to enter a six digit code. Use your 2FA app to generate the code and enter it here. (If this is the first time you've logged in, you'll be prompted to set up 2FA.)
 

--- a/articles/vmware/vmw-sco-snapshot-protection.md
+++ b/articles/vmware/vmw-sco-snapshot-protection.md
@@ -57,7 +57,7 @@ We do not guarantee successful snapshots.
 
 We can provide you with guidance on suitable candidates for Snapshot Protection (data change rate/size).
 
-VMs larger than 2TiB or with high change rates are not supported by Snapshot Protection, as the protection service will spend longer trying to establish what has changed and then attempt to back all of it up. Therefore, please contact your Service Delivery Manager if this scenario applies to one or more of your VMs.
+VMs larger than 2TiB or with high change rates are not supported by Snapshot Protection, as the protection service will spend longer trying to establish what has changed and then attempt to back all of it up. Contact your Service Delivery Manager if this scenario applies to one or more of your VMs.
 
 VM snapshots may be attempted more than once to obtain successful status.
 

--- a/articles/vmware/vmw-sco.md
+++ b/articles/vmware/vmw-sco.md
@@ -166,7 +166,7 @@ We manage the physical firewalls that face public and secure networks.
 
 **Internet-facing solutions** have 2 usable public IP addresses. You can ask for additional public IP addresses by raising a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal. We reserve the right to decline the request if you have spare capacity in your existing deployment.
 
-**PSN-facing solutions.** You should raise a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal or contact your Customer Success Manager (CSM) to be assigned your IP address. Contended bandwidth (uncapped).
+**PSN-facing solutions.** You should raise a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal to be assigned your IP address. Contended bandwidth (uncapped).
 
 **Janet and HSCN solutions** have one usable IP address. You can request additional IP addresses by raising a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal.
 
@@ -239,13 +239,11 @@ Customers are free to migrate their workloads. You can also request a migration 
 
 ## Customer service
 
-**Customer Success Manager (CSM).** For the first 90 days of the service, you have access to a UKCloud Customer Success Manager, who will help you with your adoption of the UKCloud UKCloud for VMware service,  including finding relevant systems and using UKCloud tools and processes.
+**Cloud Architect.** UKCloud Cloud Architects support you during the design of solutions for the cloud platform. UKCloud Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing complex solutions, such as those using HybridConnect or a Walled Garden.
 
-**Cloud Architects.** UKCloud Cloud Architects support you during the design of solutions for the cloud platform. UKCloud Cloud Architects are ideally placed to help reconcile your requirements with the UKCloud platform. We recommend engagement with a Cloud Architect when implementing complex solutions, such as those using HybridConnect or a Walled Garden.
+**Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Service Delivery Managers.** You will be allocated with an assigned point of contact who will provide ongoing assistance with reporting and incident escalation.
-
-**Support.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
 
 ## Customer responsibilities
 
@@ -264,8 +262,6 @@ Customers are free to migrate their workloads. You can also request a migration 
 Within 4 hours of accepting an order (shorter deployment times are typically achieved and can be prioritised upon request), UKCloud will create the customer's Primary Administrator account and send a Welcome Pack which includes the URL for the UKCloud Customer Portal, and the getting started guide. Customers can self-provision UKCloud for VMware services via the UKCloud Portal or the Portal API.
 
 UKCloud has created several videos, help guides, manuals and FAQs to help train and instruct users so that they are up and running quickly and easily. These are available within the [Knowledge Centre](https://docs.ukcloud.com/).
-
-In addition, you will be assigned a Customer Success Manager (CSM) to provide any assistance required during the first 90 days of the service.
 
 UKCloud also has a large ecosystem of partners who can deliver additional services, such as support and professional services. UKCloud would be pleased to introduce you to the right partner to suit your needs.
 


### PR DESCRIPTION
Customer Success Managers (CSMs) are now Service Delivery Managers, so need to replace instances of CSM with SDM across all articles.