### PR TITLE
Link to Portal OpenAPI reference

### DIFF
--- a/articles/portal/ptl-ref-portal-api.md
+++ b/articles/portal/ptl-ref-portal-api.md
@@ -37,7 +37,6 @@ An OpenAPI definition of the Portal API is in development.
 It can be viewed [interactively using Swagger UI](https://app.swaggerhub.com/apis-docs/ukcloud/UKCloud_Portal/development)
 and in [its raw form](https://github.com/UKCloud/create-vdc-with-edge-portal-api-demo/blob/master/docs/portal-api/openapi.json).
 
-Once complete, it will replace this document.
 
 ## Response HTTP status codes
 

--- a/articles/portal/ptl-ref-portal-api.md
+++ b/articles/portal/ptl-ref-portal-api.md
@@ -33,9 +33,8 @@ For information and examples about how to use the Portal API, see [*How to use t
 
 ## OpenAPI
 
-An OpenAPI definition of the Portal API is in development.
-It can be viewed [interactively using Swagger UI](https://app.swaggerhub.com/apis-docs/ukcloud/UKCloud_Portal/development)
-and in [its raw form](https://github.com/UKCloud/create-vdc-with-edge-portal-api-demo/blob/master/docs/portal-api/openapi.json).
+We're currently working on an OpenAPI definition of the Portal API. You can view the definition [interactively using Swagger UI](https://app.swaggerhub.com/apis-docs/ukcloud/UKCloud_Portal/development)
+or in [its raw form](https://github.com/UKCloud/create-vdc-with-edge-portal-api-demo/blob/master/docs/portal-api/openapi.json).
 
 
 ## Response HTTP status codes

--- a/articles/portal/ptl-ref-portal-api.md
+++ b/articles/portal/ptl-ref-portal-api.md
@@ -31,6 +31,14 @@ The entry point URL for the Portal API is:
 
 For information and examples about how to use the Portal API, see [*How to use the UKCloud Portal API*](ptl-how-use-api.md).
 
+## OpenAPI
+
+An OpenAPI definition of the Portal API is in development.
+It can be viewed [interactively using Swagger UI](https://app.swaggerhub.com/apis-docs/ukcloud/UKCloud_Portal/development)
+and in [its raw form](https://github.com/UKCloud/create-vdc-with-edge-portal-api-demo/blob/master/docs/portal-api/openapi.json).
+
+Once complete, it will replace this document.
+
 ## Response HTTP status codes
 
 Code | Reason


### PR DESCRIPTION
The OpenAPI reference is currently in development, but once complete, it is likely to be more useful to users.

It allows clients to be generated.
It's neater, the responses are hidden until you click through to them.
It's more consistent - curl examples are constructed automatically and correctly. 

---

Open question: Should the json file be moved to this repository?