### PR TITLE
Move all Portworx docs under 'OpenShift version 3' sub-heading

### DIFF
--- a/articles/openshift/oshift-how-add-domains-proxy-whitelist.md
+++ b/articles/openshift/oshift-how-add-domains-proxy-whitelist.md
@@ -6,7 +6,7 @@ author: Ben Bacon
 reviewer: gsmith
 lastreviewed: 20/11/2019
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-add-domains-proxy-whitelist.md
+++ b/articles/openshift/oshift-how-add-domains-proxy-whitelist.md
@@ -6,7 +6,7 @@ author: Ben Bacon
 reviewer: gsmith
 lastreviewed: 20/11/2019
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-backup-migrate.md
+++ b/articles/openshift/oshift-how-backup-migrate.md
@@ -7,7 +7,7 @@ reviewer: George Smith
 lastreviewed: 20/11/2019
 
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-backup-migrate.md
+++ b/articles/openshift/oshift-how-backup-migrate.md
@@ -7,7 +7,7 @@ reviewer: George Smith
 lastreviewed: 20/11/2019
 
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-configure-portworx-volume-replication.md
+++ b/articles/openshift/oshift-how-configure-portworx-volume-replication.md
@@ -6,7 +6,7 @@ author: Ben Bacon
 reviewer:
 lastreviewed: 14/10/2019
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2: Use Portworx with OpenShift
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-configure-portworx-volume-replication.md
+++ b/articles/openshift/oshift-how-configure-portworx-volume-replication.md
@@ -6,8 +6,8 @@ author: Ben Bacon
 reviewer:
 lastreviewed: 14/10/2019
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
-toc_sub2: Use Portworx with OpenShift
+toc_sub1: OpenShift v3.x
+toc_sub2: Portworx
 toc_sub3:
 toc_sub4:
 toc_title: Configure Portworx volume replication

--- a/articles/openshift/oshift-how-customise-error-page.md
+++ b/articles/openshift/oshift-how-customise-error-page.md
@@ -7,7 +7,7 @@ reviewer: gsmith
 lastreviewed: 20/11/2019
 
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-customise-error-page.md
+++ b/articles/openshift/oshift-how-customise-error-page.md
@@ -7,7 +7,7 @@ reviewer: gsmith
 lastreviewed: 20/11/2019
 
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-expose-nonhttp-services.md
+++ b/articles/openshift/oshift-how-expose-nonhttp-services.md
@@ -7,7 +7,7 @@ reviewer: gsmith
 lastreviewed: 20/11/2019
 
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-expose-nonhttp-services.md
+++ b/articles/openshift/oshift-how-expose-nonhttp-services.md
@@ -7,7 +7,7 @@ reviewer: gsmith
 lastreviewed: 20/11/2019
 
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-obtain-usage-metrics.md
+++ b/articles/openshift/oshift-how-obtain-usage-metrics.md
@@ -7,7 +7,7 @@ reviewer: gellner
 lastreviewed: 14/11/2019 11:15:38
 
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-obtain-usage-metrics.md
+++ b/articles/openshift/oshift-how-obtain-usage-metrics.md
@@ -7,7 +7,7 @@ reviewer: gellner
 lastreviewed: 14/11/2019 11:15:38
 
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-portworx-snapshots.md
+++ b/articles/openshift/oshift-how-portworx-snapshots.md
@@ -7,8 +7,8 @@ reviewer:
 lastreviewed: 15/10/2019
 
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
-toc_sub2: Use Portworx with OpenShift
+toc_sub1: OpenShift v3.x
+toc_sub2: Portworx
 toc_sub3:
 toc_sub4:
 toc_title: Create and restore Portworx snapshots

--- a/articles/openshift/oshift-how-portworx-snapshots.md
+++ b/articles/openshift/oshift-how-portworx-snapshots.md
@@ -7,8 +7,8 @@ reviewer:
 lastreviewed: 15/10/2019
 
 toc_rootlink: How To
-toc_sub1: Use Portworx with OpenShift
-toc_sub2:
+toc_sub1: v3
+toc_sub2: Use Portworx with OpenShift
 toc_sub3:
 toc_sub4:
 toc_title: Create and restore Portworx snapshots
@@ -24,7 +24,7 @@ Portworx is a cloud-native storage solution that is now available as an add-on t
 
 ### Intended audience
 
-This article assumes you have access to a Portworx-enabled OpenShift 3.11 or greater cluster and that you have cluster-admin rights. It also assumes familiarity with `oc`, the OpenShift command-line client. 
+This article assumes you have access to a Portworx-enabled OpenShift 3.11 or greater cluster and that you have cluster-admin rights. It also assumes familiarity with `oc`, the OpenShift command-line client.
 
 If you're interested in a free 30 day trial of Portworx, raise a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal.
 
@@ -54,12 +54,12 @@ You can take on-demand snapshots by creating an OpenShift resource of type `Volu
 
     ```none
     oc describe volumesnapshot test-snapshot-1
-    
+
     "Snapshot Data Name:            k8s-volume-snapshot-e292b115-eb4b-11e9-9d81-0a580a830007"
-    
-    
+
+
     oc describe volumesnapshotdata k8s-volume-snapshot-e292b115-eb4b-11e9-9d81-0a580a830007
-    
+
     "Message:               Snapshot created successfully and it is ready"
     ```
 
@@ -137,7 +137,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: group-snapshot-test-$i
   namespace: test-snapshot-1
-  annotations: 
+  annotations:
     volume.beta.kubernetes.io/storage-class: portworx-repl1
   labels:
     purpose: "group-test"
@@ -167,7 +167,7 @@ done
 
     ```none
     oc describe groupvolumesnapshot | grep "Volume Snapshot Name"
-    
+
         Volume Snapshot Name:  test-groupsnapshot-group-snapshot-test-2-61d7ca5e-ee87-11e9-8422-fa163e52fd0e
         Volume Snapshot Name:  test-groupsnapshot-group-snapshot-test-1-61d7ca5e-ee87-11e9-8422-fa163e52fd0e
         Volume Snapshot Name:  test-groupsnapshot-group-snapshot-test-0-61d7ca5e-ee87-11e9-8422-fa163e52fd0e
@@ -194,7 +194,7 @@ done
 
 ### Cloud snapshots
 
-Portworx enables you to backup snapshots to cloud storage. We can provide a bucket for the cluster on our Cloud Storage service and set up a cloud credential that you can use. If you'd like to configure snapshots to be sent to your own storage, see <https://docs.portworx.com/reference/cli/credentials/#overview> for how to set this up. 
+Portworx enables you to backup snapshots to cloud storage. We can provide a bucket for the cluster on our Cloud Storage service and set up a cloud credential that you can use. If you'd like to configure snapshots to be sent to your own storage, see <https://docs.portworx.com/reference/cli/credentials/#overview> for how to set this up.
 
 > [!TIP]
 > To find the ID of the cloud credentials provided with your cluster run:
@@ -210,7 +210,7 @@ Portworx enables you to backup snapshots to cloud storage. We can provide a buck
     metadata:
       name: test-cloudsnap
       namespace: test-snapshot-1
-      annotations: 
+      annotations:
         volume.beta.kubernetes.io/storage-class: portworx-repl1
     spec:
       accessModes:
@@ -337,7 +337,7 @@ The following example creates a daily policy that creates snapshots at a certain
 
     ```none
     oc get volumesnapshotschedules
-    
+
     NAME                             AGE
     test-schedule-daily-schedule     1m
     test-schedule-default-schedule   1m
@@ -385,7 +385,7 @@ Events:
   ----    ------  ----  ----   -------
   Normal  Ready   9s    stork  Scheduled snapshot (test-schedule-default-schedule-interval-2019-10-22-155402) completed successfully
   ```
-  
+
 
 ## Further reading
 

--- a/articles/openshift/oshift-how-portworx-snapshots.md
+++ b/articles/openshift/oshift-how-portworx-snapshots.md
@@ -7,7 +7,7 @@ reviewer:
 lastreviewed: 15/10/2019
 
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2: Use Portworx with OpenShift
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-publish-routes-on-multiple-networks.md
+++ b/articles/openshift/oshift-how-publish-routes-on-multiple-networks.md
@@ -6,7 +6,7 @@ author: Steve Mulholland
 reviewer: Gareth Ellner
 lastreviewed: 29/01/2020
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-publish-routes-on-multiple-networks.md
+++ b/articles/openshift/oshift-how-publish-routes-on-multiple-networks.md
@@ -6,7 +6,7 @@ author: Steve Mulholland
 reviewer: Gareth Ellner
 lastreviewed: 29/01/2020
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-use-hawkular-metrics.md
+++ b/articles/openshift/oshift-how-use-hawkular-metrics.md
@@ -7,7 +7,7 @@ reviewer: George Smith
 lastreviewed: 22/11/2019 12:39:20
 
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-use-hawkular-metrics.md
+++ b/articles/openshift/oshift-how-use-hawkular-metrics.md
@@ -7,7 +7,7 @@ reviewer: George Smith
 lastreviewed: 22/11/2019 12:39:20
 
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-use-netpol.md
+++ b/articles/openshift/oshift-how-use-netpol.md
@@ -7,7 +7,7 @@ reviewer: George Smith
 lastreviewed: 21/11/2019
 
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-use-netpol.md
+++ b/articles/openshift/oshift-how-use-netpol.md
@@ -7,7 +7,7 @@ reviewer: George Smith
 lastreviewed: 21/11/2019
 
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-use-portworx-encrypted-volumes.md
+++ b/articles/openshift/oshift-how-use-portworx-encrypted-volumes.md
@@ -6,8 +6,8 @@ author: Ben Bacon
 reviewer:
 lastreviewed: 09/10/2019
 toc_rootlink: How To
-toc_sub1: Use Portworx with OpenShift
-toc_sub2:
+toc_sub1: v3
+toc_sub2: Use Portworx with OpenShift
 toc_sub3:
 toc_sub4:
 toc_title: Use Portworx encrypted volumes
@@ -23,7 +23,7 @@ Portworx is a cloud-native storage solution that is now available as an integrat
 
 ### Intended audience
 
-This article assumes you have access to a Portworx integrated OpenShift 3.11 cluster (or later) and that you have cluster-admin rights. It also assumes familiarity with `oc`, the OpenShift command-line client. 
+This article assumes you have access to a Portworx integrated OpenShift 3.11 cluster (or later) and that you have cluster-admin rights. It also assumes familiarity with `oc`, the OpenShift command-line client.
 
 If you're interested in a free 30 day trial of Portworx, raise a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal.
 

--- a/articles/openshift/oshift-how-use-portworx-encrypted-volumes.md
+++ b/articles/openshift/oshift-how-use-portworx-encrypted-volumes.md
@@ -6,8 +6,8 @@ author: Ben Bacon
 reviewer:
 lastreviewed: 09/10/2019
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
-toc_sub2: Use Portworx with OpenShift
+toc_sub1: OpenShift v3.x
+toc_sub2: Portworx
 toc_sub3:
 toc_sub4:
 toc_title: Use Portworx encrypted volumes

--- a/articles/openshift/oshift-how-use-portworx-encrypted-volumes.md
+++ b/articles/openshift/oshift-how-use-portworx-encrypted-volumes.md
@@ -6,7 +6,7 @@ author: Ben Bacon
 reviewer:
 lastreviewed: 09/10/2019
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2: Use Portworx with OpenShift
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-use-portworx-shared-volumes.md
+++ b/articles/openshift/oshift-how-use-portworx-shared-volumes.md
@@ -7,8 +7,8 @@ reviewer:
 lastreviewed: 16/10/2019
 
 toc_rootlink: How To
-toc_sub1: Use Portworx with OpenShift
-toc_sub2:
+toc_sub1: v3
+toc_sub2: Use Portworx with OpenShift
 toc_sub3:
 toc_sub4:
 toc_title: Use Portworx shared volumes
@@ -24,7 +24,7 @@ Portworx is a cloud-native storage solution that is now available as an integrat
 
 ### Intended audience
 
-This article assumes you have access to a Portworx integrated OpenShift 3.11 cluster (or later) and that you have cluster-admin rights. It also assumes familiarity with `oc`, the OpenShift command-line client. 
+This article assumes you have access to a Portworx integrated OpenShift 3.11 cluster (or later) and that you have cluster-admin rights. It also assumes familiarity with `oc`, the OpenShift command-line client.
 
 If you're interested in a free 30 day trial of Portworx, raise a Service Request via the [My Calls](https://portal.skyscapecloud.com/support/ivanti) section of the UKCloud Portal.
 
@@ -98,13 +98,13 @@ pvc-3654b857-efa1-11e9-8422-fa163e52fd0e   10Gi       RWX            Delete     
 You can verify that a shared persistent volume is working as expected by creating two deployments that schedule to different nodes and mount the same volume. The following example assumes that you've created a shared volume named `pvc-shared`.
 
 > [!TIP]
-> The below file contains two separate [Deployments](https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/how_deployments_work.html#creating-a-deployment-configuration), as can be identified by the YAML document separator `---`. Each spec is near-identical, with the only difference being the command that the pod continually loops. 
-> 
+> The below file contains two separate [Deployments](https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/how_deployments_work.html#creating-a-deployment-configuration), as can be identified by the YAML document separator `---`. Each spec is near-identical, with the only difference being the command that the pod continually loops.
+>
 > [```nodeAffinity```](https://docs.openshift.com/container-platform/3.11/admin_guide/scheduling/node_affinity.html#admin-guide-configuring-affinity) is an affinity type used to determine which node a pod should be scheduled to, in this instance we only want the pod to be scheduled to compute nodes so the ```requiredDuringSchedulingIgnoredDuringExecution``` rule is used to check that a node contains the ```node-role.kubernetes.io/compute``` label, which is a label only applied to nodes with the compute role.
-> 
+>
 > [```podAntiAffinity```](https://docs.openshift.com/container-platform/3.11/admin_guide/scheduling/pod_affinity.html#admin-guide-sched-affinity-pod-config) is used to keep pods separate from one another. For each deployment the created pod is labelled with: ```app: portworx-sharedvolumedemo```. The ```preferredDuringSchedulingIgnoredDuringExecution``` rule then checks when scheduling a new pod whether an existing pod has already been scheduled to the same node with the previous stated label. If it does, an alternate node will be selected if there is sufficient available resources.
-> 
-> You can view OpenShift object definitions using the [```oc explain```](https://blog.openshift.com/oc-command-newbies) command. More specifically to identify fields under the Deployment spec key, you would use: ```oc explain deployment.spec```. 
+>
+> You can view OpenShift object definitions using the [```oc explain```](https://blog.openshift.com/oc-command-newbies) command. More specifically to identify fields under the Deployment spec key, you would use: ```oc explain deployment.spec```.
 
 1. On your machine, create a file named `sharedvolumedemo.yaml` with the following contents:
 

--- a/articles/openshift/oshift-how-use-portworx-shared-volumes.md
+++ b/articles/openshift/oshift-how-use-portworx-shared-volumes.md
@@ -7,7 +7,7 @@ reviewer:
 lastreviewed: 16/10/2019
 
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2: Use Portworx with OpenShift
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-use-portworx-shared-volumes.md
+++ b/articles/openshift/oshift-how-use-portworx-shared-volumes.md
@@ -7,8 +7,8 @@ reviewer:
 lastreviewed: 16/10/2019
 
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
-toc_sub2: Use Portworx with OpenShift
+toc_sub1: OpenShift v3.x
+toc_sub2: Portworx
 toc_sub3:
 toc_sub4:
 toc_title: Use Portworx shared volumes

--- a/articles/openshift/oshift-how-view-proxy-logs.md
+++ b/articles/openshift/oshift-how-view-proxy-logs.md
@@ -7,7 +7,7 @@ reviewer:
 lastreviewed: 03/12/2019
 
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-view-proxy-logs.md
+++ b/articles/openshift/oshift-how-view-proxy-logs.md
@@ -7,7 +7,7 @@ reviewer:
 lastreviewed: 03/12/2019
 
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-view-router-logs.md
+++ b/articles/openshift/oshift-how-view-router-logs.md
@@ -7,7 +7,7 @@ reviewer:
 lastreviewed:
 
 toc_rootlink: How To
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-how-view-router-logs.md
+++ b/articles/openshift/oshift-how-view-router-logs.md
@@ -7,7 +7,7 @@ reviewer:
 lastreviewed:
 
 toc_rootlink: How To
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-ref-cluster-monitoring.md
+++ b/articles/openshift/oshift-ref-cluster-monitoring.md
@@ -7,7 +7,7 @@ reviewer: Andrew Garner
 lastreviewed: 22/06/2020
 
 toc_rootlink: Reference
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-ref-cluster-monitoring.md
+++ b/articles/openshift/oshift-ref-cluster-monitoring.md
@@ -7,7 +7,7 @@ reviewer: Andrew Garner
 lastreviewed: 22/06/2020
 
 toc_rootlink: Reference
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-ref-kibana-dashboards.md
+++ b/articles/openshift/oshift-ref-kibana-dashboards.md
@@ -7,7 +7,7 @@ reviewer:
 lastreviewed:
 
 toc_rootlink: Reference
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-ref-kibana-dashboards.md
+++ b/articles/openshift/oshift-ref-kibana-dashboards.md
@@ -7,7 +7,7 @@ reviewer:
 lastreviewed:
 
 toc_rootlink: Reference
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-ref-no-proxy.md
+++ b/articles/openshift/oshift-ref-no-proxy.md
@@ -4,7 +4,7 @@ description: Provides information regarding proxy environment variables in v3.11
 services: openshift
 author: Ben Bacon
 toc_rootlink: Reference
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-ref-no-proxy.md
+++ b/articles/openshift/oshift-ref-no-proxy.md
@@ -4,7 +4,7 @@ description: Provides information regarding proxy environment variables in v3.11
 services: openshift
 author: Ben Bacon
 toc_rootlink: Reference
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-ref-scaling.md
+++ b/articles/openshift/oshift-ref-scaling.md
@@ -6,7 +6,7 @@ author: Kieran O'Neill
 reviewer: Ben Bacon
 lastreviewed: 20/03/2020
 toc_rootlink: Reference
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-ref-scaling.md
+++ b/articles/openshift/oshift-ref-scaling.md
@@ -6,7 +6,7 @@ author: Kieran O'Neill
 reviewer: Ben Bacon
 lastreviewed: 20/03/2020
 toc_rootlink: Reference
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-ref-security-best-practices.md
+++ b/articles/openshift/oshift-ref-security-best-practices.md
@@ -6,7 +6,7 @@ author: Mudasar Hussain
 reviewer: gsmith
 lastreviewed: 13/11/2019
 toc_rootlink: Reference
-toc_sub1: OpenShift version 3
+toc_sub1: OpenShift v3.x
 toc_sub2:
 toc_sub3:
 toc_sub4:

--- a/articles/openshift/oshift-ref-security-best-practices.md
+++ b/articles/openshift/oshift-ref-security-best-practices.md
@@ -6,7 +6,7 @@ author: Mudasar Hussain
 reviewer: gsmith
 lastreviewed: 13/11/2019
 toc_rootlink: Reference
-toc_sub1: v3
+toc_sub1: OpenShift version 3
 toc_sub2:
 toc_sub3:
 toc_sub4:


### PR DESCRIPTION
Move all the Portworx docs under the v3 heading.