### PR TITLE
Remove third party from toc

### DIFF
--- a/toc.yml
+++ b/toc.yml
@@ -48,8 +48,6 @@
     topicHref: articles/sra/sra-gs.md
   - name: Security Operations Service
     topicHref: articles/soc/soc-sd.md   
-  - name: Third-Party Software
-    topicHref: articles/third-party/third-ref-eula.md
   - name: UKCloud Portal
     topicHref: articles/portal/ptl-gs.md
   - name: Other


### PR DESCRIPTION
Fix build warning; no further review required