### PR TITLE
remove reference to 10GiB limit for micro VMs

### DIFF
--- a/docs/articles/vmware/vmw-sco.html
+++ b/docs/articles/vmware/vmw-sco.html
@@ -154,8 +154,6 @@
 </li>
 <li><p>Workloads can use multiple storage profiles</p>
 </li>
-<li><p>Micro sized VMs have a fixed allocation of 10GiB of Tier 2 storage which cannot be increased</p>
-</li>
 </ul>
 <h2 id="protection">Protection</h2>
 <p>Customers have a range of automated, on-platform protection options to choose from for their environments:</p>


### PR DESCRIPTION
the 10GiB storage limit for micro VMs is not enforceable.