### PR TITLE
Update Oracle video link on home page

### DIFF
--- a/articles/oracle/orcl-home.md
+++ b/articles/oracle/orcl-home.md
@@ -35,9 +35,9 @@ First, take a look at our [Getting Started Guide](orcl-gs.md) to learn the basic
 <div class="row">
   <div class="col-md-6">
     <div style="padding:56.25% 0 0 0;position:relative;">
-      <iframe src="https://www.youtube.com/embed/juhKzvCV4-g" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      <iframe src="https://www.youtube.com/embed/1tBv7dVDzbw" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
-    <p><a href="https://www.youtube.com/watch?v=juhKzvCV4-g">Oracle Enterprise Manager Cloud Control 13c Console Overview</a></p>
+    <p><a href="https://www.youtube.com/watch?v=1tBv7dVDzbw">Overview of Oracle Self Service Portal</a></p>
   </div>
   <div class="col-md-6"></div>
 </div>


### PR DESCRIPTION
Home page was using an old link for the Oracle overview video; now fixed to link to the latest video