### PR TITLE
Update product grid

### DIFF
--- a/custom_template/partials/products.tmpl.partial
+++ b/custom_template/partials/products.tmpl.partial
@@ -90,12 +90,12 @@
     <span>Other</span>
   </a>
 
-  <a href="https://www.youtube.com/channel/UCnlFUyOWcS4iE_HK-ZEcNGw" class="product-grid__item">
-    <span>UKCloud on YouTube</span>
-  </a>
-
   <a href="https://ukcloud.com/hub/" class="product-grid__item">
     <span>More Resources</span>
+  </a>
+
+  <a href="https://www.youtube.com/channel/UCnlFUyOWcS4iE_HK-ZEcNGw" class="product-grid__item">
+    <span>UKCloud on YouTube</span>
   </a>
 
   <a href="https://status.ukcloud.com/" class="product-grid__item">

--- a/custom_template/partials/products.tmpl.partial
+++ b/custom_template/partials/products.tmpl.partial
@@ -30,10 +30,6 @@
     <span>Cloud Enablement</span>
   </a>
 
-  <a href="/articles/gpu/gpu-faq.html" class="product-grid__item">
-    <span>Cloud GPU</span>
-  </a>
-
   <a href="/articles/cloud-storage/cs-gs.html" class="product-grid__item">
     <span>Cloud Storage</span>
   </a>
@@ -56,14 +52,6 @@
 
   <a href="/articles/draas/draas-gs.html" class="product-grid__item">
     <span>Disaster Recovery as a Service</span>
-  </a>
-
-  <a href="/articles/email/email-gs.html" class="product-grid__item">
-    <span>Email and Collaboration</span>
-  </a>
-
-  <a href="/articles/hpc/hpc-sd.html" class="product-grid__item">
-    <span>High Performance Compute</span>
   </a>
 
   <a href="/articles/managed-services/man-services-home.html" class="product-grid__item">
@@ -102,14 +90,26 @@
     <span>Other</span>
   </a>
 
+  <a href="https://www.youtube.com/channel/UCnlFUyOWcS4iE_HK-ZEcNGw" class="product-grid__item">
+    <span>UKCloud on YouTube</span>
+  </a>
+
   <a href="https://ukcloud.com/hub/" class="product-grid__item">
     <span>More Resources</span>
   </a>
 
+  <a href="https://status.ukcloud.com/" class="product-grid__item">
+    <span>Service Status</span>
+  </a>
+
+  <a href="mailto:feedback@ukcloud.com" class="product-grid__item">
+    <span>Feedback</span>
+  </a>
+
 </section>
 
-<div class="product-banner">
+<!-- <div class="product-banner">
   <a class="banner-link" href="mailto:feedback@ukcloud.com">
     <img class="banner" src="{{_rel}}styles/assets/banner.jpg" srcset="{{_rel}}styles/assets/banner.jpg 2x" width="1436px" alt="Feedback" >
   </a>
-</div>
+</div> -->


### PR DESCRIPTION
- Update product grid on KC homepage to remove EOS products (GPU, Email, HPC).
- Add additional links to fill in the gaps (YouTube, Content Hub, Status page and Feedback email
- Remove feedback banner as this is now covered in a tile on the product grid

EOS products are still accessible from the home page via the products menu (under More) at the top of the page