### PR TITLE
Update ostack-how-move-resources.md

### DIFF
--- a/articles/openstack/ostack-how-move-resources.md
+++ b/articles/openstack/ostack-how-move-resources.md
@@ -137,7 +137,7 @@ To achieve this across different regions, the use of a VPN may be required. Deta
 
     - Enter the following command:
 
-          openstack image create  --file <path-to-file-to-upload> --disk-format qcow2 --container-format bare <name-for-upload>
+          openstack image create  --file <path-to-file-to-upload> --disk-format raw --container-format bare <name-for-upload>
 
 5. To create a new volume in the target region based upon the original source volume, enter the following command:
 

--- a/articles/openstack/ostack-how-move-resources.md
+++ b/articles/openstack/ostack-how-move-resources.md
@@ -82,7 +82,11 @@ The following provides a code example of how to achieve this export and import o
 4. To download source image snapshot, enter the following command:
 
         openstack image save <id-of-image-to-download> --file <image-name> 
-
+        
+        If the image size is greater than the memory of the local host the following may be required
+        
+        glance image-download --file <output-location> --progress <id-of-image-to-download>
+        
 5. To upload source image to the target region:
 
     - Source the target region's `cred rc` file
@@ -130,6 +134,11 @@ To achieve this across different regions, the use of a VPN may be required. Deta
 3. Download the source volume image to your local device using the following command:
 
         openstack image save <id-of-image-to-download> --file <image-name> 
+        
+        If the image size is greater than the memory of the local host the following may be required
+        
+        glance image-download --file <output-location> --progress <id-of-image-to-download>
+
 
 4. To upload the source volume image to the target region:
 

--- a/articles/openstack/ostack-how-move-resources.md
+++ b/articles/openstack/ostack-how-move-resources.md
@@ -4,7 +4,7 @@ description: Helps you understand how you can move resources between OpenStack r
 services: openstack
 author: Sue Highmoor
 reviewer: bnicholls
-lastreviewed: 05/01/2021
+lastreviewed: 29/01/2021
 
 toc_rootlink: How To
 toc_sub1:
@@ -82,14 +82,14 @@ The following provides a code example of how to achieve this export and import o
 4. To download source image snapshot, enter the following command:
 
         openstack image save <id-of-image-to-download> --file <image-name> 
-        
-        If the image size is greater than the memory of the local host the following may be required
+
+    If the image size is greater than the memory of the local host, the following may be required:
         
         glance image-download --file <output-location> --progress <id-of-image-to-download>
         
 5. To upload source image to the target region:
 
-    - Source the target region's `cred rc` file
+    - Source the target region's `cred rc` file.
 
     - Enter the following command:
 

--- a/articles/openstack/ostack-how-move-resources.md
+++ b/articles/openstack/ostack-how-move-resources.md
@@ -89,7 +89,7 @@ The following provides a code example of how to achieve this export and import o
         
 5. To upload source image to the target region:
 
-    - Source the target region's `cred rc` file.
+    - Source the target region's `cred rc` file
 
     - Enter the following command:
 
@@ -134,11 +134,10 @@ To achieve this across different regions, the use of a VPN may be required. Deta
 3. Download the source volume image to your local device using the following command:
 
         openstack image save <id-of-image-to-download> --file <image-name> 
-        
-        If the image size is greater than the memory of the local host the following may be required
+
+    If the image size is greater than the memory of the local host the following may be required
         
         glance image-download --file <output-location> --progress <id-of-image-to-download>
-
 
 4. To upload the source volume image to the target region:
 

--- a/articles/openstack/ostack-how-move-resources.md
+++ b/articles/openstack/ostack-how-move-resources.md
@@ -135,7 +135,7 @@ To achieve this across different regions, the use of a VPN may be required. Deta
 
         openstack image save <id-of-image-to-download> --file <image-name> 
 
-    If the image size is greater than the memory of the local host the following may be required
+    If the image size is greater than the memory of the local host, the following may be required:
         
         glance image-download --file <output-location> --progress <id-of-image-to-download>
 


### PR DESCRIPTION
Updated the Volume Upload from qcow2 to RAW, using QCOW2 meant the uploaded image would not be converted to a volume successfully.