### PR TITLE
Dark theme - Fix colours of the 'caution' blocks

### DIFF
--- a/custom_template/styles/main.css
+++ b/custom_template/styles/main.css
@@ -106,7 +106,7 @@ h1, h2, h3, h4, h5 {
   background-color: var(--color-background-alert-warning);
   border-color: var(--color-background-alert-warning);
 }
-.IMPORTANT {
+.IMPORTANT, .CAUTION {
   color: var(--color-foreground-alert-important);
   background-color: var(--color-background-alert-important);
   border-color: var(--color-background-alert-important);


### PR DESCRIPTION
Spotted an issue with the 'caution' blocks, where the colours are not handled correctly for the dark theme. These blocks are identical in colour to the 'important' blocks, so I've applied the same CSS to their class.

Old:
![image](https://user-images.githubusercontent.com/61973249/108877349-0cf9c700-75f7-11eb-8fb9-710564736e58.png)

New:
![image](https://user-images.githubusercontent.com/61973249/108877414-200c9700-75f7-11eb-82ec-ef091ef8002e.png)
