### PR TITLE
Remove refs to UKCloud Community

### DIFF
--- a/articles/enablement/enbl-sco-transfer-regions.md
+++ b/articles/enablement/enbl-sco-transfer-regions.md
@@ -81,4 +81,4 @@ The following documents contain more information about the Zerto and the service
 
 ## Feedback
 
-If you find an issue with this article, click **Improve this Doc** to suggest a change. If you have an idea for how we could improve any of our services, visit the [Ideas](https://community.ukcloud.com/ideas) section of the [UKCloud Community](https://community.ukcloud.com).
+If you find a problem with this article, click **Improve this Doc** to make the change yourself or raise an [issue](https://github.com/UKCloud/documentation/issues) in GitHub. If you have an idea for how we could improve any of our services, send an email to <feedback@ukcloud.com>.

--- a/articles/openstack/ostack-sco-triliovault.md
+++ b/articles/openstack/ostack-sco-triliovault.md
@@ -95,5 +95,5 @@ If neither of these services meet your requirements, you can also implement and 
 
 ## Feedback
 
-If you find an issue with this article, click **Improve this Doc** to suggest a change. If you have an idea for how we could improve any of our services, visit the [Ideas](https://community.ukcloud.com/ideas) section of the [UKCloud Community](https://community.ukcloud.com).
+If you find a problem with this article, click **Improve this Doc** to make the change yourself or raise an [issue](https://github.com/UKCloud/documentation/issues) in GitHub. If you have an idea for how we could improve any of our services, send an email to <feedback@ukcloud.com>.
 

--- a/articles/other/other-ref-discount-schemes.md
+++ b/articles/other/other-ref-discount-schemes.md
@@ -129,4 +129,4 @@ UKCloud Desktop as a Service          | &check;             | &nbsp;            
 
 ## Feedback
 
-If you find an issue with this article, click **Improve this Doc** to suggest a change. If you have an idea for how we could improve any of our services, visit the [Ideas](https://community.ukcloud.com/ideas) section of the [UKCloud Community](https://community.ukcloud.com).
+If you find a problem with this article, click **Improve this Doc** to make the change yourself or raise an [issue](https://github.com/UKCloud/documentation/issues) in GitHub. If you have an idea for how we could improve any of our services, send an email to <feedback@ukcloud.com>.

--- a/articles/other/other-ref-maintenance-windows.md
+++ b/articles/other/other-ref-maintenance-windows.md
@@ -43,4 +43,4 @@ If, during Emergency Maintenance, there is a loss of availability to the service
 
 ## Feedback
 
-If you find an issue with this article, click **Improve this Doc** to suggest a change. If you have an idea for how we could improve any of our services, visit the [Ideas](https://community.ukcloud.com/ideas) section of the [UKCloud Community](https://community.ukcloud.com).
+If you find a problem with this article, click **Improve this Doc** to make the change yourself or raise an [issue](https://github.com/UKCloud/documentation/issues) in GitHub. If you have an idea for how we could improve any of our services, send an email to <feedback@ukcloud.com>.

--- a/articles/portal/ptl-gs.md
+++ b/articles/portal/ptl-gs.md
@@ -186,7 +186,7 @@ The Portal navigation panel provides access to all the functionality available i
 
   - The Zerto Self-Service Portal (ZSSP) where you can manage Journaling Protection, Disaster Recovery to the Cloud and Workload Migration to the Cloud (see [*How to perform a failover*](../vmware/vmw-how-zerto-perform-failover.md)).
 
-- **Communities** - Access the UKCloud Community LinkedIn group, Content Hub and UKCloud repositories on GitHub.
+- **Communities** - Access the UKCloud LinkedIn group, Content Hub and UKCloud repositories on GitHub.
 
 ### Content area
 

--- a/articles/vmware/vmw-how-upgrade-edge.md
+++ b/articles/vmware/vmw-how-upgrade-edge.md
@@ -156,4 +156,4 @@ Another way to upgrade a vApp network is to shut down the vApp and restart it. R
 
 ## Feedback
 
-If you find an issue with this article, click **Improve this Doc** to suggest a change. If you have an idea for how we could improve any of our services, visit the [Ideas](https://community.ukcloud.com/ideas) section of the [UKCloud Community](https://community.ukcloud.com).
+If you find a problem with this article, click **Improve this Doc** to make the change yourself or raise an [issue](https://github.com/UKCloud/documentation/issues) in GitHub. If you have an idea for how we could improve any of our services, send an email to <feedback@ukcloud.com>.


### PR DESCRIPTION
Discovered a few random references to the old UKCloud Community site. This pull request removes those references.