### PR TITLE
Update articles to show FRN6 as OSP13

### DIFF
--- a/articles/openstack/ostack-faq.md
+++ b/articles/openstack/ostack-faq.md
@@ -169,8 +169,8 @@ The answer to this depends on which of UKCloud's OpenStack platforms you are usi
 
 | Region              | OpenStack version                      | LBaaS supported? |
 |---------------------|----------------------------------------|------------------|
-| COR00005 <BR> FRN00006 | OpenStack Platform 10 <BR>(Newton Release) | No, as OpenStack Neutron does not support highly-available load balancing services. <BR> UKCloud has created [*How to creating load balancing services on UKCloud for OpenStack*](ostack-how-create-load-balancer.md), which describes how to deploy a HA load balancing solution. |
-| COR00005-2 | OpenStack Platform 13 <BR> (Queens Release) | In Beta* - Uses the [OpenStack Octavia](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html/networking_guide/sec-octavia) project. |
+| COR00005 | OpenStack Platform 10 <BR>(Newton Release) | No, as OpenStack Neutron does not support highly-available load balancing services. <BR> UKCloud has created [*How to creating load balancing services on UKCloud for OpenStack*](ostack-how-create-load-balancer.md), which describes how to deploy a HA load balancing solution. |
+| COR00005-2 <BR> FRN00006 | OpenStack Platform 13 <BR> (Queens Release) | In Beta* - Uses the [OpenStack Octavia](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html/networking_guide/sec-octavia) project. |
   
 <i> *Beta allows early access to new features for testing and feedback purposes. Although UKCloud has performed testing in production, we cannot warrant for the use within a customer's production environment. </i>
 
@@ -230,8 +230,8 @@ The answer to this depends on which of UKCloud's OpenStack services you are usin
 
 | Region              | OpenStack version                      | Encrypted volumes supported? |
 |---------------------|----------------------------------------|------------------|
-| COR00005 <BR> FRN00006 | OpenStack Platform 10 <BR>(Newton Release) | No, as Red Hat's Newton release does not support native Key Management as a Service (KMaaS) to underpin encryption  |
-| COR00005-2 | OpenStack Platform 13 <BR> (Queens Release) | In Beta* |
+| COR00005 | OpenStack Platform 10 <BR>(Newton Release) | No, as Red Hat's Newton release does not support native Key Management as a Service (KMaaS) to underpin encryption  |
+| COR00005-2 <BR> FRN00006 | OpenStack Platform 13 <BR> (Queens Release) | In Beta* |
 
 <i> *Beta allows early access to new features for testing and feedback purposes. Although UKCloud has performed testing in production, we cannot warrant for the use within a customer's production environment. </i>
 
@@ -289,8 +289,8 @@ The answer to this depends on which of UKCloud's OpenStack platforms you are usi
 
 | Region              | OpenStack version                      | KMaaS supported? |
 |---------------------|----------------------------------------|------------------|
-| COR00005 <BR> FRN00006 | OpenStack Platform 10 <BR>(Newton Release) | No, customers will need to deploy their own Key Management solution. |
-| COR00005-2 | OpenStack Platform 13 <BR> (Queens Release) | Yes, using OpenStack's Barbican service. You can find further information [here](https://docs.ukcloud.com/articles/openstack/ostack-how-use-barbican.html). |
+| COR00005 | OpenStack Platform 10 <BR>(Newton Release) | No, customers will need to deploy their own Key Management solution. |
+| COR00005-2 <BR> FRN00006 | OpenStack Platform 13 <BR> (Queens Release) | Yes, using OpenStack's Barbican service. You can find further information [here](https://docs.ukcloud.com/articles/openstack/ostack-how-use-barbican.html). |
 
 ### What reports can I get about instances performance?
 

--- a/articles/openstack/ostack-how-create-load-balancer.md
+++ b/articles/openstack/ostack-how-create-load-balancer.md
@@ -19,7 +19,7 @@ toc_mdlink: ostack-how-create-load-balancer.md
 # Creating load-balancing services on UKCloud for OpenStack
 
 > [!NOTE]
-> This article only applies to OpenStack Regions running the Newton release and lower (currently COR00005 and FRN00006). All newer Regions offer native Load Balancing as a Service (LBaaS)
+> This article only applies to OpenStack Regions running the Newton release and lower (currently COR00005). All other Regions offer native Load Balancing as a Service (LBaaS)
 
 ## Overview
 

--- a/articles/openstack/ostack-how-use-barbican.md
+++ b/articles/openstack/ostack-how-use-barbican.md
@@ -19,7 +19,7 @@ toc_mdlink: ostack-how-use-barbican.md
 # Using Barbican Key Management as a Service (KMaaS)
 
 > [!NOTE]
-> This article does not apply to OpenStack Regions running the Pike release and lower (currently COR00005 and FRN00006). All newer Regions offer native Key Management as a Service
+> This article does not apply to OpenStack Regions running the Pike release and lower (currently COR00005). All other Regions offer native Key Management as a Service
 
 ## Overview
 

--- a/articles/openstack/ostack-ref-dashboard.md
+++ b/articles/openstack/ostack-ref-dashboard.md
@@ -24,8 +24,8 @@ For an overview on how to use OpenStack's Horizon dashboard to drive the platfor
 
 | Region              | OpenStack Version                      | Documentation |
 |---------------------|----------------------------------------|---------------|
-| COR00005 <BR> FRN00006 | OpenStack Platform 10 <BR> (Newton Release) | [*Red Hat OpenStack Platform 10 - Introduction to the OpenStack Dashboard*](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/10/pdf/introduction_to_the_openstack_dashboard/Red_Hat_OpenStack_Platform-10-Introduction_to_the_OpenStack_Dashboard-en-US.pdf) |
-| COR00005-2 | OpenStack Platform 13 <BR> (Queens Release) | [*Red Hat OpenStack Platform 13 - Introduction to the OpenStack Dashboard* ](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/pdf/introduction_to_the_openstack_dashboard/Red_Hat_OpenStack_Platform-13-Introduction_to_the_OpenStack_Dashboard-en-US.pdf) |
+| COR00005 | OpenStack Platform 10 <BR> (Newton Release) | [*Red Hat OpenStack Platform 10 - Introduction to the OpenStack Dashboard*](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/10/pdf/introduction_to_the_openstack_dashboard/Red_Hat_OpenStack_Platform-10-Introduction_to_the_OpenStack_Dashboard-en-US.pdf) |
+| COR00005-2 <BR> FRN00006 | OpenStack Platform 13 <BR> (Queens Release) | [*Red Hat OpenStack Platform 13 - Introduction to the OpenStack Dashboard* ](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/pdf/introduction_to_the_openstack_dashboard/Red_Hat_OpenStack_Platform-13-Introduction_to_the_OpenStack_Dashboard-en-US.pdf) |
 
 ## Feedback
 

--- a/articles/openstack/ostack-sco.md
+++ b/articles/openstack/ostack-sco.md
@@ -49,9 +49,9 @@ The following OpenStack projects/services are available with UKCloud for OpenSta
 
 - Neutron Networking Services
 
-- Barbican Key Management Services (*Excludes COR00005 & FRN00006 Regions*)
+- Barbican Key Management Services (*Excludes COR00005 Region*)
 
-- Octavia Load Balancing as a Service (*Excludes COR00005 & FRN00006 Regions*)
+- Octavia Load Balancing as a Service (*Excludes COR00005 Region*)
 
 - Self-service backup and restoration, powered by TrilioVault (*Excludes COR00005*)
 


### PR DESCRIPTION
As per changes made in other articles, updated remaining articles that reference FRN6 to indicate that this region now runs OSP13