### PR TITLE
Update conn-ref-psn-core-services.md

### DIFF
--- a/articles/connectivity/conn-ref-psn-core-services.md
+++ b/articles/connectivity/conn-ref-psn-core-services.md
@@ -3,8 +3,8 @@ title: Understanding PSN core services
 description: Outlines the responsibilities between you and UKCloud with regards to Public Services Network (PSN) core services, such as DNS and email filtering. 
 services: connectivity
 author: Sue Highmoor
-reviewer: Chris Aldridge
-lastreviewed: 06/08/2020 16:08
+reviewer: nstobbart
+lastreviewed: 05/08/2021 16:08
 toc_rootlink: Reference
 toc_sub1: 
 toc_sub2:
@@ -19,7 +19,7 @@ toc_mdlink: conn-ref-psn-core-services.md
 
 ## Overview
 
-This document outlines the responsibilities between you and UKCloud with regards to Public Services Network (PSN) core services, such as DNS and email filtering.
+This document outlines the responsibilities between you and UKCloud with regards to Public Services Network (PSN) core services, such as DNS.
 
 The intended audience is organisations who are either consuming or presenting a service over the PSN --- both PSN Assured and PSN Protected.
 
@@ -29,33 +29,33 @@ In this article, we use PSN to represent both PSN Protected and PSN Assured unle
 
 ## PSN core services
 
-While you can procure PSN connectivity from multiple service providers, PSN core services are provided by Vodafone only. Traditionally, this was through the GSI Convergence Framework (GCF), whereby all core services were bundled into a single contract, regardless of whether you used them all.
+While you can procure PSN connectivity from multiple service providers, PSN core services are provided by Vodafone (gateways) & Nominet (DNS). Traditionally, this was through the GSI Convergence Framework (GCF), whereby all core services were bundled into a single contract, regardless of whether you used them all.
 
 Core services include:
 
 - DNS
 
-- Network Time Protocol (NTP)
-
-- Email filtering and relay
-
 - Gateways to other networks, both government and public
 
 UKCloud has procured PSN connectivity on your behalf, giving you access to the PSN through a shared bandwidth model. We'll supply you with PSN IP addresses, enabling you to present and consume services over the PSN.
 
-PSN connectivity **does not** grant you access to PSN core services. Access to these must be purchased as a separate contract with Vodafone, and is available through Government Digital Marketplace (G-Cloud) or via Direct Award through the Network Services Framework with Vodafone. If you are a commercial organisation then you can take a contract out directly with Vodafone for core services.
+PSN connectivity **does not** grant you access to PSN core services. Access to these must be purchased as a separate contract with Vodafone, and is available through Government Digital Marketplace (G-Cloud) or via Direct Award through the Network Services Framework with Vodafone. If you are a commercial organisation then you can take a contract out directly with Vodafone or Nominet for core services.
 
 ## Making changes to PSN core services
 
-When you have a contract with Vodafone for PSN core services, you can add and change these to suit your service.
+When you have a contract with Vodafone or Nominet for PSN core services, you can add and change these to suit your service.
 
-To add or change the core services, complete the appropriate forms and send them to Vodafone for approval to raise a change. Depending on the contract you have with Vodafone, you will need to raise these changes differently.
+To add or change the core services, complete the appropriate forms and send them to Vodafone or Nominet for approval to raise a change. Depending on the contract you have with Vodafone or Nominet , you will need to raise these changes differently.
 
 ### GCF contract customers
 
 If you have a GCF contract still in place with Vodafone, complete and submit the GCF change form:
 
 <https://www.gov.uk/government/publications/gcf-customer-change-form>
+
+For DNS changes a ticket should be raised with Nominet:
+
+<https://nominetpsn.atlassian.net>
 
 ### G-Cloud, direct award or commercial contract customers
 
@@ -73,13 +73,13 @@ All requests for changes to the core services must come from the core service co
 
 ### Customer responsibility
 
-When you're given PSN connectivity by UKCloud, we'll provide you with all the IP information you require to submit a PSN core service change request to Vodafone. You are responsible for the creation of domain names and additional information that may need to be submitted in the change form.
+When you're given PSN connectivity by UKCloud, we'll provide you with all the IP information you require to submit a PSN core service change request to Vodafone or Nominet. You are responsible for the creation of domain names and additional information that may need to be submitted in the change form.
 
 You are responsible for completing and submitting the PSN core service change forms.
 
 ### UKCloud's responsibility
 
-UKCloud has no responsibility for facilitating a contract between Vodafone and our customers or partners for PSN core services. You must approach and contract with Vodafone directly.
+UKCloud has no responsibility for facilitating a contract between Vodafone or Nominet and our customers or partners for PSN core services. You must approach and contract with Vodafone or Nominet directly.
 
 UKCloud has no responsibility for completing or submitting any change forms for changes to PSN core services on behalf of customers or partners. We may help you complete the form but you are ultimately responsible for validating and submitting the forms. UKCloud does not accept responsibility for incorrect information supplied within the change forms.
 
@@ -87,27 +87,25 @@ UKCloud has no responsibility for completing or submitting any change forms for 
 
 In certain circumstances, there may be complex aspects to responsibility:
 
-- **Scenario 1** - If a non-government organisation has not got a direct contract with Vodafone, but is contracted through a managed service provider, then responsibilities may be shared between the organisation and MSP.
+- **Scenario 1** - If a non-government organisation has not got a direct contract with Vodafone or Nominet, but is contracted through a managed service provider, then responsibilities may be shared between the organisation and MSP.
 
     Both parties may need to complete the form, however as per GDS guidance, it is ultimately the domain contract owner who owns the validation and submission of the forms. The domain contract should sit with the non-government organisation and not the managed service provider.
 
-- **Scenario 2** - If a non-government organisation is currently hosted on a different hosting provider, and is thinking about moving to UKCloud, then they need to consider their current contracting relationship for core services with Vodafone.
+- **Scenario 2** - If a non-government organisation is currently hosted on a different hosting provider, and is thinking about moving to UKCloud, then they need to consider their current contracting relationship for core services with Vodafone or Nominet.
 
-    If the non-government organisation has no direct contract with Vodafone but is contracted through the hosting provider, then when they move to UKCloud they may need to take out a new contract directly with Vodafone for PSN core services.
+    If the non-government organisation has no direct contract with Vodafone or Nominet but is contracted through the hosting provider, then when they move to UKCloud they may need to take out a new contract directly with Vodafone or Nominet for PSN core services.
 
     Another consideration is the domain contract ownership. As only the domain contract owner can validate and submit change requests, it's important to ensure that the domain is owned by the non-government organisation, and not the hosting provider. If the hosting provider is the current domain contract owner, then the non-government organisation should work with the hosting provider to change the ownership before moving services to UKCloud.
 
 ## New PSN DNS
 
-A new PSN DNS is being developed that will be free at the point of use for PSN users, relieving them of the responsibility to contract with Vodafone for DNS services. This is currently not fully operational so should not yet be relied upon, however it may be worth signing up to have early access to it upon availability.
+A new PSN DNS is being developed that will be free at the point of use for PSN users, relieving them of the responsibility to contract with Nominet for DNS services. 
 
 For more information visit <https://www.gov.uk/guidance/introducing-the-uk-public-sector-dns>
 
 ## More information
 
 For more information about PSN, see the [*Public Services Network (PSN) FAQs*](conn-faq-psn.md).
-
-For an overview of the future of PSN, including updates about email and DNS services, see our blog post, [*The new future of PSN*](https://ukcloud.com/hub/news/the-new-future-of-psn/).
 
 ## Feedback
 

--- a/articles/connectivity/conn-ref-psn-core-services.md
+++ b/articles/connectivity/conn-ref-psn-core-services.md
@@ -2,9 +2,9 @@
 title: Understanding PSN core services
 description: Outlines the responsibilities between you and UKCloud with regards to Public Services Network (PSN) core services, such as DNS and email filtering. 
 services: connectivity
-author: Sue Highmoor
+author: shighmoor
 reviewer: nstobbart
-lastreviewed: 05/08/2021 16:08
+lastreviewed: 05/08/2021
 toc_rootlink: Reference
 toc_sub1: 
 toc_sub2:
@@ -29,7 +29,7 @@ In this article, we use PSN to represent both PSN Protected and PSN Assured unle
 
 ## PSN core services
 
-While you can procure PSN connectivity from multiple service providers, PSN core services are provided by Vodafone (gateways) & Nominet (DNS). Traditionally, this was through the GSI Convergence Framework (GCF), whereby all core services were bundled into a single contract, regardless of whether you used them all.
+While you can procure PSN connectivity from multiple service providers, PSN core services are provided by Vodafone (gateways) and Nominet (DNS). Traditionally, this was through the GSI Convergence Framework (GCF), whereby all core services were bundled into a single contract, regardless of whether you used them all.
 
 Core services include:
 


### PR DESCRIPTION
Removed references to the NTP and mail relay services which no longer exist. Added multiple references to Nominet who now own the PSN DNS service. Article might be a good candidate to be completely re-written following these changes?