### PR TITLE
Add EOS notice for Oracle articles

### DIFF
--- a/articles/azure/azs-ref-pricing.md
+++ b/articles/azure/azs-ref-pricing.md
@@ -89,7 +89,7 @@ For more information about the discount and purchase schemes offered by UKCloud,
 
 - Microsoft Windows Server licences must be provided by UKCloud and you'll be billed per hour based on the powered-on state of the host VM.
 
-- If you want to host Oracle solutions on our platform, consult our Cloud Architects, or consider our Dedicated Compute v2 or UKCloud for Oracle Software services to avoid licensing issues.
+- If you want to host Oracle solutions on our platform, consult our Cloud Architects, or consider our Dedicated Compute v2 or Private Cloud for Oracle Software services to avoid licensing issues.
 
 ## Billing and payment information
 

--- a/articles/openstack/ostack-ref-pricing.md
+++ b/articles/openstack/ostack-ref-pricing.md
@@ -117,7 +117,7 @@ For more information about the discount and purchase schemes offered by UKCloud,
 
 - Microsoft Windows Server licences must be provided by UKCloud and you'll be billed per hour based on the powered-on state of the host VM.
 
-- If you want to host Oracle solutions on our platform, consult our Cloud Architects, or consider our Dedicated Compute v2 or UKCloud for Oracle Software services to avoid licensing issues.
+- If you want to host Oracle solutions on our platform, consult our Cloud Architects, or consider our Dedicated Compute v2 or Private Cloud for Oracle Software services to avoid licensing issues.
 
 ### Snapshots
 

--- a/articles/oracle/orcl-faq.md
+++ b/articles/oracle/orcl-faq.md
@@ -17,6 +17,9 @@ toc_mdlink: orcl-faq.md
 
 # UKCloud for Oracle Software FAQs
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## General
 
 ### What is UKCloud for Oracle Software?

--- a/articles/oracle/orcl-gs.md
+++ b/articles/oracle/orcl-gs.md
@@ -18,6 +18,9 @@ toc_mdlink: orcl-gs.md
 
 # Getting Started Guide for UKCloud for Oracle Software
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## Overview
 
 UKCloud for Oracle Software provides Infrastructure-as-a-Service (IaaS), powered by Oracle VM (OVM) technology, that is fully compliant with the compatibility and licensing requirements of Oracle-based enterprise applications.

--- a/articles/oracle/orcl-home.md
+++ b/articles/oracle/orcl-home.md
@@ -17,6 +17,9 @@ toc_mdlink: orcl-home.md
 
 # UKCloud for Oracle Software
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## Let's get started
 
 First, take a look at our [Getting Started Guide](orcl-gs.md) to learn the basics, then you can:

--- a/articles/oracle/orcl-how-build-vm.md
+++ b/articles/oracle/orcl-how-build-vm.md
@@ -18,6 +18,9 @@ toc_mdlink: orcl-how-build-vm.md
 
 # How to build an Oracle virtual machine
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## Overview
 
 UKCloud for Oracle Software provides Infrastructure-as-a-Service (IaaS), powered by Oracle VM (OVM) technology, that is fully compliant with the compatibility and licensing requirements of Oracle-based enterprise applications.

--- a/articles/oracle/orcl-how-enable-ha.md
+++ b/articles/oracle/orcl-how-enable-ha.md
@@ -18,6 +18,9 @@ toc_mdlink: orcl-how-enable-ha.md
 
 # How to enable high availability for your Oracle VMs
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## Overview
 
 Owing to the nature of Oracle workloads and the need to pin them to processor cores, workloads will be automatically moved in the event of a host failure only if you've enabled the high availability (HA) feature

--- a/articles/oracle/orcl-ref-bug-self-service.md
+++ b/articles/oracle/orcl-ref-bug-self-service.md
@@ -17,6 +17,9 @@ toc_mdlink: orcl-ref-bug-self-service.md
 
 # Oracle cloud self-service functionality (bug notification)
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## Overview
 
 Due to a bug that has been identified within the Oracle cloud placement engine, until further notice, customers on the Oracle cloud will be unable to perform the following tasks through the Oracle cloud portal:

--- a/articles/oracle/orcl-ref-db-backup.md
+++ b/articles/oracle/orcl-ref-db-backup.md
@@ -17,6 +17,9 @@ toc_mdlink: orcl-ref-db-backup.md
 
 # Best practice guidelines for Oracle Database backup
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## Overview
 
 This article provides some guidelines for setting up and managing Oracle Database backups for workloads on the UKCloud for Oracle Software service.

--- a/articles/oracle/orcl-ref-licensing.md
+++ b/articles/oracle/orcl-ref-licensing.md
@@ -17,6 +17,9 @@ toc_mdlink: orcl-ref-licensing.md
 
 # Oracle licensing on the UKCloud platform
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## Overview
 
 Due to the licensing rules regarding Oracle, it is not possible to install and run processor-based Oracle software on UKCloud for VMware, UKCloud for OpenStack or UKCloud for Microsoft Azure. However, you can use UKCloud for Oracle Software to run Oracle applications and databases. This is a solution specifically designed using Oracle VM hypervisor technology to enable Oracle licensing to be used correctly. It is also financially efficient as you only need to license software for resources used.
@@ -38,7 +41,7 @@ Oracle Enterprise Linux (OEL) is a free x86 operating system (OS) that Oracle pr
 
 ## Per processor
 
-This type of licence is typical of Oracle Database (both Enterprise and Standard) and enables you to have as many users as you need for a fixed cost ‘per processor’ that the servers run on.
+This type of licence is typical of Oracle Database (both Enterprise and Standard) and enables you to have as many users as you need for a fixed cost 'per processor' that the servers run on.
 
 As UKCloud runs Oracle VM (OVM) as the hypervisor technology for UKCloud for Oracle Software, you can simply license the processors (cores) that you require for your application and database VMs, rather than *all* the processors within the cluster.
 

--- a/articles/oracle/orcl-ref-pricing.md
+++ b/articles/oracle/orcl-ref-pricing.md
@@ -17,6 +17,9 @@ toc_mdlink: orcl-ref-pricing.md
 
 # Pricing information for UKCloud for Oracle Software
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## Overview
 
 UKCloud for Oracle Software VM pricing can be as low as 9p per hour. Full pricing with all options, including licensing and connectivity, is available in the [UKCloud Pricing Guide](https://ukcloud.com/pricing-guide).

--- a/articles/oracle/orcl-ref-rac.md
+++ b/articles/oracle/orcl-ref-rac.md
@@ -18,6 +18,9 @@ toc_mdlink: orcl-ref-rac.md
 
 # RAC on UKCloud for Oracle Software
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## Overview
 
 Oracle Real Application Clusters (RAC) shares an Oracle database across multiple servers, removing the database as a potential single point of failure and increasing application availability.

--- a/articles/oracle/orcl-ref-solaris-aix.md
+++ b/articles/oracle/orcl-ref-solaris-aix.md
@@ -18,6 +18,9 @@ toc_mdlink: orcl-ref-solaris-aix.md
 
 # Compatibility with Solaris and AIX
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## Overview
 
 This article provides advice about how you can migrate your applications to UKCloud for Oracle Software depending on the Oracle platform you're using.

--- a/articles/oracle/orcl-ref-templates.md
+++ b/articles/oracle/orcl-ref-templates.md
@@ -18,6 +18,9 @@ toc_mdlink: orcl-ref-templates.md
 
 # UKCloud for Oracle Software templates
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 UKCloud for Oracle Software provides several templates in a public library to help you build your Oracle virtual machines (VMs). An Oracle VM template is a fully pre-installed, pre-configured VM image that you can use to quickly create new VMs without having to worry about OS installation and configuration.
 
 UKCloud provides the following templates:
@@ -45,3 +48,7 @@ UKCloud provides the following templates:
 - Microsoft Windows Server 2016 DataCenter Edition 64-bit
 
 - Microsoft Windows Server 2012 R2 DataCenter Edition 64-bit
+
+## Feedback
+
+If you find a problem with this article, click **Improve this Doc** to make the change yourself or raise an [issue](https://github.com/UKCloud/documentation/issues) in GitHub. If you have an idea for how we could improve any of our services, send an email to <feedback@ukcloud.com>.

--- a/articles/oracle/orcl-ref-vm-compatibility.md
+++ b/articles/oracle/orcl-ref-vm-compatibility.md
@@ -17,6 +17,9 @@ toc_mdlink: orcl-ref-vm-compatibility.md
 
 # VM compatibility with UKCloud for Oracle Software
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## Introduction
 
 This article outlines what you need to do to make sure your Oracle VMs (OVMs) are compatible with UKCloud for Oracle Software service. You may find this useful if you're moving VMs from UKCloud for VMware to UKCloud for Oracle Software.

--- a/articles/oracle/orcl-sco.md
+++ b/articles/oracle/orcl-sco.md
@@ -17,6 +17,9 @@ toc_mdlink: orcl-sco.md
 
 # UKCloud for Oracle Software Service Scope
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## About this document
 
 This document describes the boundaries of the UKCloud for Oracle software service, along with the division of responsibilities between UKCloud and the customer, to facilitate the provisioning and ongoing use of the service.

--- a/articles/oracle/orcl-sd.md
+++ b/articles/oracle/orcl-sd.md
@@ -17,6 +17,9 @@ toc_mdlink: orcl-sd.md
 
 # UKCloud for Oracle Software Service Definition
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 ## What is UKCloud for Oracle Software?
 
 UKCloud for Oracle Software provides a proven Oracle Infrastructure as a Service that's tailor made for running your Oracle workloads in the cloud. This service enables you to move technologies such as Oracle Database, Oracle WebLogic Server, Oracle Primavera, E-Business Suite and more to our secure sovereign cloud platform quickly and easily, while enjoying the economies of scale of the cloud. You can then connect your Oracle applications to the non-Oracle workloads that you have within the rest of the multi-cloud ecosystem. It is billed hourly and supported free of charge.

--- a/articles/oracle/orcl-vid-overview.md
+++ b/articles/oracle/orcl-vid-overview.md
@@ -17,6 +17,9 @@ toc_mdlink: orcl-vid-overview.md
 
 # Video: Overview of Oracle Self Service Portal
 
+> [!IMPORTANT]
+> UKCloud for Oracle Software has been retired from sale by UKCloud. We'll continue to support all existing customers who are using this service, however, we are no longer providing this service for new workloads. This article provides existing UKCloud for Oracle Software customers with access to support documentation and we'll continue to update it as required. For new Oracle requests, contact your Client Director or Service Delivery Manager.
+
 The following video provides an introduction to the Oracle Enterprise Manager (OEM) Cloud Control 13c Console, showing you the different tasks that you can perform.
 
 <div class="row">

--- a/articles/other/other-faq-sla.md
+++ b/articles/other/other-faq-sla.md
@@ -303,6 +303,9 @@ How much is payable?
 
 ## UKCloud for Oracle Software
 
+> [!IMPORTANT]
+> This service is no longer available for sale. The following information is provided to support existing customers of the service only.
+
 ### How do you offer an SLA on UKCloud for Oracle Software?
 
 UKCloud monitors two main components of the UKCloud for Oracle Software service to provide the best overall measure of service availability. The first component is the physical host server that the Oracle Virtual Machine (OVM) is running on. This confirms that the OVM has resources and can be available. The second component is the data store which ensures that the storage associated with the OVM is accessible. By monitoring these two components, UKCloud believes that we can provide the best overall view of the availability of the service.

--- a/articles/other/other-ref-high-availability.md
+++ b/articles/other/other-ref-high-availability.md
@@ -99,6 +99,9 @@ To help your applications cope with variable demand, you can configure Orchestra
 
 ### UKCloud for Oracle Software
 
+> [!IMPORTANT]
+> This service is no longer available for sale. The following information is provided to support existing customers of the service only.
+
 In UKCloud for Oracle Software, you can enable HA on a virtual machine so that it can be automatically migrated to a surviving node in the event of a failure. For more information, see [*How to enable high availability for your Oracle VMs*](../oracle/orcl-how-enable-ha.md).
 
 If your VM is running an Oracle database and you're using hard partitioning to reduce licensing costs, virtual CPUs are pinned to physical cores and the HA option is not available. In the event of a failure, VMs must be manually migrated to a new host and will require restarting.

--- a/articles/other/other-ref-product-overview.md
+++ b/articles/other/other-ref-product-overview.md
@@ -115,7 +115,11 @@ This article is designed to provide you with a top level comparison for our main
 ***
 
 > [!NOTE]
-> Email and Collaboration as a Service is no longer available for sale. It is included in this article to support existing customers of the product only.
+> The following products are no longer available for sale. They are included in this article to support existing customers of the products only.
+>
+> - Email and Collaboration as a Service
+>
+> - UKCloud for Oracle Software
 
 ## Feedback
 

--- a/articles/other/other-ref-sla-definition.md
+++ b/articles/other/other-ref-sla-definition.md
@@ -99,6 +99,9 @@ UKCloud monitors the customer self-service UKCloud Portal, (<https://portal.ukcl
 
 ### UKCloud for Oracle Software
 
+> [!IMPORTANT]
+> This service is no longer available for sale. The following information is provided to support existing customers of the service only.
+
 &nbsp;                       | UKCloud for Oracle Software
 -----------------------------|----------------------------
 **Availability commitment**  | **Non-HA:** 99.95%<br>**HA:** 99.99%
@@ -174,6 +177,9 @@ UKCloud monitors the customer self-service UKCloud Portal, (<https://portal.ukcl
 Due to the service being dependent on connectivity between the customer data centre and UKCloud, we are unable to offer an SLA relating to the performance of this service. For full details of the SLA for the UKCloud for VMware platform that hosts the solution, see [*UKCloud for VMware*](#ukcloud-for-vmware).
 
 ### Email and Collaboration as a Service
+
+> [!IMPORTANT]
+> This service is no longer available for sale. The following information is provided to support existing customers of the service only.
 
 &nbsp;                       | Email and Collaboration as a Service
 -----------------------------|-------------------------------------

--- a/articles/other/other-sco-free-trials.md
+++ b/articles/other/other-sco-free-trials.md
@@ -49,6 +49,8 @@ Exclusions are:
 
 - Private Cloud for Oracle Software
 
+- UKCloud for Microsoft Azure
+
 - Government network where Code of Connection is not held (for example, PSN or HSCN; see relevant connectivity FAQ)
 
 - Products in alpha or beta testing - these will be treated differently to free trials

--- a/articles/vmware/vmw-ref-pricing.md
+++ b/articles/vmware/vmw-ref-pricing.md
@@ -203,7 +203,7 @@ For more information about the discount and purchase schemes offered by UKCloud,
 
 - Microsoft Windows Server licences must be provided by UKCloud and you'll be billed per hour based on the powered-on state of the host VM.
 
-- If you want to host Oracle solutions on our platform, consult our Cloud Architects, or consider our Dedicated Compute v2 or UKCloud for Oracle Software services to avoid licensing issues.
+- If you want to host Oracle solutions on our platform, consult our Cloud Architects, or consider our Dedicated Compute v2 or Private Cloud for Oracle Software services to avoid licensing issues.
 
 ### Snapshots
 


### PR DESCRIPTION
Update Oracle articles to notify users that UKCloud for Oracle Software is an end-of-sale product.