### PR TITLE
feat: remove tmp from api curls

### DIFF
--- a/articles/portal/ptl-how-use-api.md
+++ b/articles/portal/ptl-how-use-api.md
@@ -54,8 +54,8 @@ The Portal API uses session authentication. Before calling any of the API endpoi
       jq --arg email "$portal_email" --arg password "$portal_password" --null-input '{email: $email, password: $password}'
       )"
         
-      curl -c /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/authenticate' -X POST -d "$authentication_body" -H 'Content-Type: application/json'
-      ```
+        curl -c cookies.txt 'https://portal.skyscapecloud.com/api/authenticate' -X POST -d "$authentication_body" -H 'Content-Type: application/json'
+        ```
 
       > [!NOTE]
       > Install jq if you don't already have it:
@@ -89,7 +89,7 @@ To create a VDC, you need to know the ID of the account in which you want to cre
     For example:
 
     ```
-    curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts' | jq
+    curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts' | jq
     ```
 
     If you need to authenticate to the Portal API first, see [Authenticating to the API](#authenticating-to-the-api).
@@ -123,7 +123,7 @@ Each account can have multiple vOrgs associated with it, so you also need to kno
         For example:
 
         ```
-        curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/676/vorgs/' | jq
+        curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/676/vorgs/' | jq
         ```
 
 3. This returns a list of vOrgs associated with the specified account.
@@ -175,7 +175,7 @@ When you have the account and vOrg IDs, you can go ahead and create your VDC.
     For example:
 
     ```
-    curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/676/vorgs/2/vdcs' -i -X POST -d '{
+    curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/676/vorgs/2/vdcs' -i -X POST -d '{
       "data": {
         "type": "VDC",
         "attributes": {
@@ -220,7 +220,7 @@ When you have the account and vOrg IDs, you can go ahead and create your VDC.
         In our example, the build ID is `9`, so we can send the following request:
 
     ```
-    curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/vdc-builds/9' | jq
+    curl -b cookies.txt 'https://portal.skyscapecloud.com/api/vdc-builds/9' | jq
     ```
 
 6. If the build has started and is still in progress, the `state` changes to `running`. For example:
@@ -288,7 +288,7 @@ The first thing you need to do is find the URN of the VDC for which you want to 
         For example:
 
         ```
-        curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/676/vorgs/2/vdcs' | jq
+        curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/676/vorgs/2/vdcs' | jq
         ```
 
 3. This returns a list of VDCs associated with the specified vOrg.
@@ -349,7 +349,7 @@ Now that you have your VDC URN, you can use the Portal API to create your edge g
     For example:
 
     ```
-    curl -b /tmp/cookies.txt -i 'https://portal.skyscapecloud.com/api/accounts/676/vorgs/2/vdcs/urn:vcloud:vdc:1a7570ea-29d9-4090-9714-75c262a123ad/edge-gateways' -X POST -d '{
+    curl -b cookies.txt -i 'https://portal.skyscapecloud.com/api/accounts/676/vorgs/2/vdcs/urn:vcloud:vdc:1a7570ea-29d9-4090-9714-75c262a123ad/edge-gateways' -X POST -d '{
       "data": {
         "type": "EdgeGateway",
         "attributes": {
@@ -389,7 +389,7 @@ Now that you have your VDC URN, you can use the Portal API to create your edge g
     For example:
 
     ```
-    curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/edge-gateway-builds/10' | jq
+    curl -b cookies.txt 'https://portal.skyscapecloud.com/api/edge-gateway-builds/10' | jq
     ```
 
 6. when the edge gateway has been successfully created, the `state` changes to completed. For example:

--- a/articles/portal/ptl-ref-portal-api.md
+++ b/articles/portal/ptl-ref-portal-api.md
@@ -80,7 +80,7 @@ None
 read portal_email # Enter your Portal email address
 read -s portal_password # Enter your Portal password
 
-curl -c /tmp/cookies.txt -X POST -H 'Content-Type: application/json' -d '{"email": "'"$portal_email"'", "password": "'"$portal_password"'"}' 'https://portal.skyscapecloud.com/api/authenticate'
+curl -c cookies.txt -X POST -H 'Content-Type: application/json' -d '{"email": "'"$portal_email"'", "password": "'"$portal_password"'"}' 'https://portal.skyscapecloud.com/api/authenticate'
 ```
 
 #### Example request (Ruby)
@@ -112,7 +112,7 @@ cookies = resp.env[:response_headers]['set-cookie']
 The endpoint also returns a session cookie that provides authentication for your API calls. You must send this cookie with any subsequent authenticated call, for example:
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts'
 ```
 
 #### Example response
@@ -142,7 +142,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/ping'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/ping'
 ```
 
 #### Example request (Ruby)
@@ -192,7 +192,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts'
 ```
 
 #### Example request (Ruby)
@@ -277,7 +277,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/compute_services?page=10&per_page=20'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/compute_services?page=10&per_page=20'
 ```
 
 #### Example request (Ruby)
@@ -706,7 +706,7 @@ For information about how to find the vOrg ID, see [*GET /api/accounts/:account_
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/compute_services/12'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/compute_services/12'
 ```
 
 ### Response
@@ -794,7 +794,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/api_credentials'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/api_credentials'
 ```
 
 #### Example request (Ruby)
@@ -882,7 +882,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/vorgs'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/vorgs'
 ```
 
 #### Example request (Ruby)
@@ -1050,7 +1050,7 @@ zone id | The zone in which to create the vOrg</br>Valid values:</br>- B (for re
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt https://portal.skyscapecloud.com/api/accounts/53/vorgs -X POST -d '{"data": {"type": "Vorg", "attributes": {"zoneId": "B", "name": "DEMO"}}}' -H 'Content-Type: application/json'
+curl -b cookies.txt https://portal.skyscapecloud.com/api/accounts/53/vorgs -X POST -d '{"data": {"type": "Vorg", "attributes": {"zoneId": "B", "name": "DEMO"}}}' -H 'Content-Type: application/json'
 ```
 
 ### Response
@@ -1189,7 +1189,7 @@ None
 #### Example request
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/vorg-builds/10'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/vorg-builds/10'
 ```
 
 ### Response
@@ -1327,7 +1327,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/vorg-builds'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/vorg-builds'
 ```
 
 #### Example request (Ruby)
@@ -1531,7 +1531,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/vorgs/12/vdcs'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/vorgs/12/vdcs'
 ```
 
 ### Response
@@ -1693,7 +1693,7 @@ vmType | The type of VM workloads used in the VDC</br>Valid values:</br>- POWER<
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt https://portal.skyscapecloud.com/api/accounts/53/vorgs/1/vdcs -X POST -d '{"data": {"type": "VDC", "attributes": {"vmType": "POWER", "name": "DEMO"}}}' -H 'Content-Type: application/json'
+curl -b cookies.txt https://portal.skyscapecloud.com/api/accounts/53/vorgs/1/vdcs -X POST -d '{"data": {"type": "VDC", "attributes": {"vmType": "POWER", "name": "DEMO"}}}' -H 'Content-Type: application/json'
 ```
 
 ### Response
@@ -1856,7 +1856,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/vdc-builds/10'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/vdc-builds/10'
 ```
 
 ### Response
@@ -2007,7 +2007,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/vdc-builds'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/vdc-builds'
 ```
 
 #### Example request (Ruby)
@@ -2233,7 +2233,7 @@ connectivityType | The type of connection</br>Valid values:</br>- Internet (in t
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt https://portal.skyscapecloud.com/api/accounts/53/vorgs/1/vdcs/urn:vcloud:vdc:345a5d90-1c8c-4fb2-bf4f-f480de82c594/edge-gateways -X POST -d '{"data": {"type": "EdgeGateway", "attributes": {"connectivityType": "Internet"}}}' -H 'Content-Type: application/json'
+curl -b cookies.txt https://portal.skyscapecloud.com/api/accounts/53/vorgs/1/vdcs/urn:vcloud:vdc:345a5d90-1c8c-4fb2-bf4f-f480de82c594/edge-gateways -X POST -d '{"data": {"type": "EdgeGateway", "attributes": {"connectivityType": "Internet"}}}' -H 'Content-Type: application/json'
 ```
 
 ### Response
@@ -2351,7 +2351,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/edge-gateway-builds/23'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/edge-gateway-builds/23'
 ```
 
 ### Response
@@ -2458,7 +2458,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/edge-gateway-builds'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/edge-gateway-builds'
 ```
 
 #### Example request (Ruby)
@@ -2646,7 +2646,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/platform_visibility/vmotion_events'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/accounts/1/platform_visibility/vmotion_events'
 ```
 
 #### Example request (Ruby)
@@ -2741,7 +2741,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/billing/cloud-storage-report?date=2018-01-01&org_id=xx-xx-xx-xxxxxxx'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/billing/cloud-storage-report?date=2018-01-01&org_id=xx-xx-xx-xxxxxxx'
 ```
 
 #### Example request (Ruby)
@@ -2809,7 +2809,7 @@ None
 #### Example request (Curl)
 
 ```bash
-curl -b /tmp/cookies.txt 'https://portal.skyscapecloud.com/api/billing/billing-csv?period=2018-01&org_id=xx-xx-xx-xxxxxxx'
+curl -b cookies.txt 'https://portal.skyscapecloud.com/api/billing/billing-csv?period=2018-01&org_id=xx-xx-xx-xxxxxxx'
 ```
 
 #### Example request (Ruby)


### PR DESCRIPTION
The reason being that the cookie represents your login authentication credential and so putting it in /tmp means that any user on the system can act as you by using your cookie. This is not good security. - Mark Young