### PR TITLE
Add info about D@RE for VMware

### DIFF
--- a/articles/other/other-ref-services-by-region.md
+++ b/articles/other/other-ref-services-by-region.md
@@ -68,7 +68,7 @@ Elevated | **UKCloud for VMware**<br>*Connectivity:* PSN, HybridConnect, CrownCo
 
 Security domain | Services | Zone
 -----------------|---------|-----
-Assured | **UKCloud for VMware**<br>*Connectivity:* Internet, PSN, HSCN, Janet, HybridConnect, CrownConnect<br>*VM type:* ESSENTIAL, POWER, PRIORITY<br>*Storage:* Tier 1, Tier 2<br>*Protection:* Journaling, Snapshot<br>Bring Your Own Firewall | Zone 2D
+Assured | **UKCloud for VMware**<br>*Connectivity:* Internet, PSN, HSCN, Janet, HybridConnect, CrownConnect<br>*VM type:* ESSENTIAL, POWER, PRIORITY<br>*Storage:* Tier 1, Tier 2, Always-on data at rest encryption (D@RE)<br>*Protection:* Journaling, Snapshot<br>Bring Your Own Firewall | Zone 2D
 
 *Enablement services:* Disaster Recovery as a Service, Migration to the Cloud, Mass Transfer Facility, Cloud Enablement<br>
 *Cross Domain Security Zone:* Walled Garden, Secure Remote Access
@@ -99,7 +99,7 @@ Elevated | **UKCloud for VMware**<br>*Connectivity:* PSN, HybridConnect, CrownCo
 
 Security domain | Service | Zone
 -----------------|--------|-----
-Assured | **UKCloud for VMware**<br>*Connectivity:* Internet, PSN, HSCN, Janet, HybridConnect, CrownConnect<br>*VM type:* ESSENTIAL, POWER, PRIORITY<br>*Storage:* Tier 1, Tier 2<br>*Protection:* Journaling, Snapshot<br>Bring Your Own Firewall | Zone B
+Assured | **UKCloud for VMware**<br>*Connectivity:* Internet, PSN, HSCN, Janet, HybridConnect, CrownConnect<br>*VM type:* ESSENTIAL, POWER, PRIORITY<br>*Storage:* Tier 1, Tier 2, Always-on data at rest encryption (D@RE)<br>*Protection:* Journaling, Snapshot<br>Bring Your Own Firewall | Zone B
 &nbsp; | **UKCloud for OpenStack** (OSP10)<br>*Connectivity:* Internet, PSN, HSCN, Janet<br>*VM type:* Ephemeral<br>*Storage:* Tier 1, Tier 2 | Zone C
 &nbsp; | **UKCloud for OpenStack** (OSP13)<br>*Connectivity:* Internet, PSN, HSCN, Janet<br>*VM type:* Ephemeral<br>*Storage:* Tier 1, Tier 2 | Zone 26
 &nbsp; | **UKCloud for Red Hat OpenShift**<br>*Connectivity:* Internet, PSN, HSCN, Janet | Zone C

--- a/articles/vmware/vmw-faq.md
+++ b/articles/vmware/vmw-faq.md
@@ -112,6 +112,10 @@ UKCloud for VMware provides always-on data at rest encryption (D@RE) in Regions 
 
 In other regions UKCloud can supply licensing for HyTrust DataControl. Alternatively, you can implement encryption using the technology of your choice inside the VM's operating system.
 
+### Does your data at rest encryption solution provide FIPS 140-2 or Common Criteria certification?
+
+We use Pure Storage for our data at rest encryption solution in regions 13 and 14, which is FIPS 140-2 and Common Criteria certified.
+
 ### Is UKCloud's encryption service available for UKCloud for VMware?
 
 Not currently as a service (see above). We're considering this as an option, so please provide feedback by sending an email to <feedback@ukcloud.com>.

--- a/articles/vmware/vmw-faq.md
+++ b/articles/vmware/vmw-faq.md
@@ -108,9 +108,9 @@ Alternatively, we offer the Mass Transfer Facility option enabling customers to 
 
 ### Does UKCloud offer encryption on the VM?
 
-Not by default, however UKCloud can supply licensing for HyTrust DataControl. This solution offers powerful data-at-rest encryption with integrated key management to secure VMs and their data throughout their lifecycle, from deployment to decommission.
+UKCloud for VMware provides always-on data at rest encryption (D@RE) in Regions 13 and 14.
 
-Alternatively, you can implement encryption using the technology of your choice inside the VM's operating system.
+In other regions UKCloud can supply licensing for HyTrust DataControl. Alternatively, you can implement encryption using the technology of your choice inside the VM's operating system.
 
 ### Is UKCloud's encryption service available for UKCloud for VMware?
 


### PR DESCRIPTION
Update services by region article to indicate that data at rest encryption (D@RE) is available in regions 13 and 14
Update encryption question in VMware FAQ to state the availability of D@RE in regions 13 and 14