### PR TITLE
Remove reference to old RHUI (Now Decom) and RHEL6 EUS

### DIFF
--- a/articles/shared/shared-how-install-rhui-vm-3.md
+++ b/articles/shared/shared-how-install-rhui-vm-3.md
@@ -4,7 +4,7 @@ description: Shows you how to update your existing VMs to target UKCloud's appro
 services: shared-services
 author: shighmoor
 reviewer: pcantle
-lastreviewed: 19/04/2021
+lastreviewed: 28/09/2021
 toc_rootlink: How To
 toc_sub1: 
 toc_sub2:
@@ -28,8 +28,6 @@ As of November 2020, UKCloud implemented the latest version of RHUI to continue 
 - Replication of packages between Assured and Elevated is significantly faster.
 
 - Root CA signed SSL certificates are now in use for HTTPS communication to the RHUI Content Delivery Systems (CDS).
-
-This latest version of RHUI replaces the previous version (from 2015), which is soon to be decommissioned.
 
 ### Intended audience
 
@@ -60,13 +58,9 @@ You can browse the list of installer RPM files [here](https://rh-cds.ukcloud.com
 
 - [RHEL 6 Standard](https://rh-cds.ukcloud.com/redhat/client_rpms/UKCloud-Client-RHEL6-STANDARD-2.0-3.noarch.rpm)
 
-- [RHEL 6 EUS](https://rh-cds.ukcloud.com/redhat/client_rpms/UKCloud-Client-RHEL6-EUS-2.0-2.noarch.rpm)
-
 - [RHEL 6 ELS](https://rh-cds.ukcloud.com/redhat/client_rpms/UKCloud-Client-RHEL6-ELS-2.0-2.noarch.rpm)
 
 - [RHEL 7 Standard](https://rh-cds.ukcloud.com/redhat/client_rpms/UKCloud-Client-RHEL7-STANDARD-2.0-5.noarch.rpm)
-
-- [RHEL 7 EUS](https://rh-cds.ukcloud.com/redhat/client_rpms/UKCloud-Client-RHEL7-EUS-2.0-2.noarch.rpm)
 
 - [RHEL 8 Standard](https://rh-cds.ukcloud.com/redhat/client_rpms/UKCloud-Client-RHEL8-STANDARD-2.0-7.noarch.rpm)
 

--- a/articles/shared/shared-ref-rhui-3.md
+++ b/articles/shared/shared-ref-rhui-3.md
@@ -4,7 +4,7 @@ description: Provides information about the UKCloud Red Hat Update Infrastructur
 services: shared-services
 author: shighmoor
 reviewer: pcantle
-lastreviewed: 19/07/2021
+lastreviewed: 28/09/2021
 toc_rootlink: Reference
 toc_sub1: 
 toc_sub2:
@@ -36,18 +36,6 @@ This article is intended for customers who have configured their systems to use 
 ## Repository groups
 
 The UKCloud RHUI service supplies access to the following repository groups. Each group is installed by a configuration RPM. You can install only one configuration RPM per client machine.
-
-### RHEL6-Standard
-
-- Red Hat Enterprise Linux 6 Server - Extras from RHUI (RPMs) (x86_64)
-
-- Red Hat Enterprise Linux 6 Server - Optional from RHUI (RPMs) (6Server-x86_64)
-
-- Red Hat Enterprise Linux 6 Server from RHUI (RPMs) (6Server-x86_64)
-     
-- Red Hat Enterprise Linux 6 Server - Supplementary from RHUI (RPMs) (6Server-x86_64)
-
-- Red Hat Software Collections for RHEL Server from RHUI (RPMs) (6Server-x86_64)
 
 ### RHEL6-ELS
 


### PR DESCRIPTION
A bit of a tidy up to remove reference to the old RHUI being shutdown as well as remove links/references to EUS packages for RHEL6/7