### PR TITLE
OpenShift v4 scaling

### DIFF
--- a/articles/openshift/oshift-how-scale-cluster-v4.md
+++ b/articles/openshift/oshift-how-scale-cluster-v4.md
@@ -11,8 +11,8 @@ toc_sub2:
 toc_sub3:
 toc_sub4:
 toc_title: Scale an OpenShift v4 cluster
-toc_fullpath: How To/oshift-how-v4-scale.md
-toc_mdlink: oshift-how-v4-scale.md
+toc_fullpath: How To/oshift-how-scale-cluster-v4.md
+toc_mdlink: oshift-how-scale-cluster-v4.md
 ---
 
 # How to scale an OpenShift v4 cluster

--- a/articles/openshift/oshift-how-use-netpol-v4.md
+++ b/articles/openshift/oshift-how-use-netpol-v4.md
@@ -13,7 +13,7 @@ toc_sub3:
 toc_sub4:
 toc_title: Use NetworkPolicy objects in OpenShift v4
 toc_fullpath: How To/OpenShift v4.x/oshift-how-use-netpol-v4.md
-toc_mdlink: oshift-how-use-netpol.md
+toc_mdlink: oshift-how-use-netpol-v4.md
 ---
 
 # How to use NetworkPolicy objects to connect services between projects

--- a/articles/openshift/oshift-how-v4-scale.md
+++ b/articles/openshift/oshift-how-v4-scale.md
@@ -21,22 +21,18 @@ In OpenShift v4 clusters, worker nodes are managed by "MachineSets". These are o
 
 To view available MachineSets and their current scale, check the "Compute ... MachineSets" section of the OpenShift web console, or run the following oc command:
 
-    ```bash
     oc get MachineSets -n openshift-machine-api
-    ```
+
 
 To scale a MachineSet up or down, set the scale against the MachineSet in the OpenShift web console, or run:
 
-    ```bash
     oc scale MachineSet <machinesetname> -n openshift-machine-api --replicas=<scale>
-	# Where <machinesetname> is the name of the MachineSet to scale, and <scale> is the number of workers desired from that MachineSet
-    ```
+    # Where <machinesetname> is the name of the MachineSet to scale, and <scale> is the number of workers desired from that MachineSet
+
 
 After approximately 3 minutes, the new nodes should be visible in the OpenShift web console or in the output of:
 
-    ```bash
     oc get nodes
-    ```
 	
 > [!NOTE]
 > When a MachineSet is scaled down, some workers will be drained and deleted. Workloads will automatically restart on remaining nodes if sufficient capacity remains. If all worker MachineSets are scaled to "0", workloads may stop completely.

--- a/articles/openshift/oshift-how-v4-scale.md
+++ b/articles/openshift/oshift-how-v4-scale.md
@@ -15,29 +15,64 @@ toc_fullpath: How To/oshift-how-v4-scale.md
 toc_mdlink: oshift-how-v4-scale.md
 ---
 
-# Considerations when scaling an OpenShift cluster
+# How to scale an OpenShift v4 cluster
 
-### Infrastructure applications
+In OpenShift v4 clusters, worker nodes are managed by "MachineSets". These are objects which define the configuration of worker nodes, and can be scaled to set the number of workers of that type in the cluster.
+
+To view available MachineSets and their current scale, check the "Compute ... MachineSets" section of the OpenShift web console, or run the following oc command:
+
+    ```bash
+    oc get MachineSets -n openshift-machine-api
+    ```
+
+To scale a MachineSet up or down, set the scale against the MachineSet in the OpenShift web console, or run:
+
+    ```bash
+    oc scale MachineSet <machinesetname> -n openshift-machine-api --replicas=<scale>
+	# Where <machinesetname> is the name of the MachineSet to scale, and <scale> is the number of workers desired from that MachineSet
+    ```
+
+After approximately 3 minutes, the new nodes should be visible in the OpenShift web console or in the output of:
+
+    ```bash
+    oc get nodes
+    ```
+	
+> [!NOTE]
+> When a MachineSet is scaled down, some workers will be drained and deleted. Workloads will automatically restart on remaining nodes if sufficient capacity remains. If all worker MachineSets are scaled to "0", workloads may stop completely.
 
 
-#### Recommendations
+### Default MachineSets available
 
+UKCloud offers three charging models for OpenShift workers:
+- Hourly - This is charged by the hour, with a 1 hour minimum charge.
+- Monthly - This is charged by the month, with a 1 month minimum charge. However, when used for the entire month, the cost is lower than running a hourly worker for the entire month.
+- Annual - This is charged by the year, with a 1 year minimum charge. However, when used for the entire year, the cost is lower than running a monthly worker for the entire year. If you would like annual MachineSets added to your cluster, please raise a Service Request via the My Calls section of the UKCloud Portal and provide us with the size, network connectivity of the MachineSets you'd like to add.
 
-### Planning your scale out
+Hourly MachineSets are particularly useful for short-term testing or for bursts of demand.
 
+By default, UKCloud OpenShift clusters have the following MachineSets available:
+- <clusterid>-hourly-m1-medium - 4 CPU, 16GB RAM - charged by the hour
+- <clusterid>-monthly-m1-medium - 4 CPU, 16GB RAM - charged by the month
+- <clusterid>-hourly-r1-small - 8 CPU, 16GB RAM - charged by the hour
+- <clusterid>-monthly-r1-small - 8 CPU, 16GB RAM - charged by the month
+- <clusterid>-hourly-m1-large - 4 CPU, 32B RAM - charged by the hour
+- <clusterid>-monthly-m1-large - 4 CPU, 32GB RAM - charged by the month
+- <clusterid>-hourly-r1-medium -  8 CPU, 32GB RAM - charged by the month
+- <clusterid>-monthly-r1-medium - 8 CPU, 32GB RAM - charged by the month
 
-### Scaling
-
+Costs for each flavour and charging model can be found in section 2.1.3 of the [UKCloud Pricing Guide](https://ukcloud.com/pricing-guide)
 
 > [!NOTE]
-> The network connectivity you request for the scaled up nodes must be present in the cluster.
+> MachineSets for larger flavours of node can be added by UKCloud - raise a Service Request via the My Calls section of the UKCloud Portal and provide us with the size, network connectivity of the MachineSets you'd like to add.
+
+
 
 ### Further information
 
-Below are some useful OpenShift documentation pages regarding scaling of a cluster:
+For more information, see the Red Hat OpenShift Documentation:
+https://docs.openshift.com/container-platform/4.8/machine_management/manually-scaling-machineset.html
 
-https://docs.openshift.com/container-platform/3.11/scaling_performance/scaling_cluster_metrics.html
-https://docs.openshift.com/container-platform/3.11/scaling_performance/scaling_cluster_monitoring.html
 
 ## Feedback
 

--- a/articles/openshift/oshift-how-v4-scale.md
+++ b/articles/openshift/oshift-how-v4-scale.md
@@ -52,14 +52,14 @@ UKCloud offers three charging models for OpenShift workers:
 Hourly MachineSets are particularly useful for short-term testing or for bursts of demand.
 
 By default, UKCloud OpenShift clusters have the following MachineSets available:
-- <clusterid>-hourly-m1-medium - 4 CPU, 16GB RAM - charged by the hour
-- <clusterid>-monthly-m1-medium - 4 CPU, 16GB RAM - charged by the month
-- <clusterid>-hourly-r1-small - 8 CPU, 16GB RAM - charged by the hour
-- <clusterid>-monthly-r1-small - 8 CPU, 16GB RAM - charged by the month
-- <clusterid>-hourly-m1-large - 4 CPU, 32B RAM - charged by the hour
-- <clusterid>-monthly-m1-large - 4 CPU, 32GB RAM - charged by the month
-- <clusterid>-hourly-r1-medium -  8 CPU, 32GB RAM - charged by the month
-- <clusterid>-monthly-r1-medium - 8 CPU, 32GB RAM - charged by the month
+- `<clusterid>-hourly-m1-medium` - 4 CPU, 16GB RAM - charged by the hour
+- `<clusterid>-monthly-m1-medium` - 4 CPU, 16GB RAM - charged by the month
+- `<clusterid>-hourly-r1-small` - 8 CPU, 16GB RAM - charged by the hour
+- `<clusterid>-monthly-r1-small` - 8 CPU, 16GB RAM - charged by the month
+- `<clusterid>-hourly-m1-large` - 4 CPU, 32B RAM - charged by the hour
+- `<clusterid>-monthly-m1-large` - 4 CPU, 32GB RAM - charged by the month
+- `<clusterid>-hourly-r1-medium` -  8 CPU, 32GB RAM - charged by the month
+- `<clusterid>-monthly-r1-medium` - 8 CPU, 32GB RAM - charged by the month
 
 Costs for each flavour and charging model can be found in section 2.1.3 of the [UKCloud Pricing Guide](https://ukcloud.com/pricing-guide)
 

--- a/articles/openshift/oshift-how-v4-scale.md
+++ b/articles/openshift/oshift-how-v4-scale.md
@@ -1,0 +1,44 @@
+---
+title: Scale an OpenShift v4 cluster
+description: Describes how to do self-service scaling in OpenShift v4
+services: openshift
+author: Gareth Ellner
+reviewer: 
+lastreviewed: 
+toc_rootlink: How To
+toc_sub1: OpenShift v4.x
+toc_sub2:
+toc_sub3:
+toc_sub4:
+toc_title: Scale an OpenShift v4 cluster
+toc_fullpath: How To/oshift-how-v4-scale.md
+toc_mdlink: oshift-how-v4-scale.md
+---
+
+# Considerations when scaling an OpenShift cluster
+
+### Infrastructure applications
+
+
+#### Recommendations
+
+
+### Planning your scale out
+
+
+### Scaling
+
+
+> [!NOTE]
+> The network connectivity you request for the scaled up nodes must be present in the cluster.
+
+### Further information
+
+Below are some useful OpenShift documentation pages regarding scaling of a cluster:
+
+https://docs.openshift.com/container-platform/3.11/scaling_performance/scaling_cluster_metrics.html
+https://docs.openshift.com/container-platform/3.11/scaling_performance/scaling_cluster_monitoring.html
+
+## Feedback
+
+If you find a problem with this article, click **Improve this Doc** to make the change yourself or raise an [issue](https://github.com/UKCloud/documentation/issues) in GitHub. If you have an idea for how we could improve any of our services, send an email to <feedback@ukcloud.com>.

--- a/articles/openshift/oshift-how-v4-scale.md
+++ b/articles/openshift/oshift-how-v4-scale.md
@@ -1,10 +1,10 @@
 ---
-title: Scale an OpenShift v4 cluster
-description: Describes how to do self-service scaling in OpenShift v4
+title: How to scale an OpenShift v4 cluster
+description: Describes how to perform self-service scaling in OpenShift v4
 services: openshift
-author: Gareth Ellner
+author: gellner
 reviewer: 
-lastreviewed: 
+lastreviewed: 29/09/2021
 toc_rootlink: How To
 toc_sub1: OpenShift v4.x
 toc_sub2:
@@ -17,58 +17,68 @@ toc_mdlink: oshift-how-v4-scale.md
 
 # How to scale an OpenShift v4 cluster
 
-In OpenShift v4 clusters, worker nodes are managed by "MachineSets". These are objects which define the configuration of worker nodes, and can be scaled to set the number of workers of that type in the cluster.
+## Overview
 
-To view available MachineSets and their current scale, check the "Compute ... MachineSets" section of the OpenShift web console, or run the following oc command:
+In OpenShift v4 clusters, worker nodes are managed by "MachineSets". These are objects that define the configuration of worker nodes, and can be scaled to set the number of workers of that type in the cluster.
+
+## Scaling an OpenShift v4 cluster
+
+To view available MachineSets and their current scale, check the *Compute ... MachineSets* section of the OpenShift web console, or run the following oc command:
 
     oc get MachineSets -n openshift-machine-api
-
 
 To scale a MachineSet up or down, set the scale against the MachineSet in the OpenShift web console, or run:
 
     oc scale MachineSet <machinesetname> -n openshift-machine-api --replicas=<scale>
-    # Where <machinesetname> is the name of the MachineSet to scale, and <scale> is the number of workers desired from that MachineSet
+    
+Where `<machinesetname>` is the name of the MachineSet to scale, and `<scale>` is the number of workers desired from that MachineSet.
 
-
-After approximately 3 minutes, the new nodes should be visible in the OpenShift web console or in the output of:
+After approximately three minutes, the new nodes should be visible in the OpenShift web console or in the output of:
 
     oc get nodes
 	
 > [!NOTE]
-> When a MachineSet is scaled down, some workers will be drained and deleted. Workloads will automatically restart on remaining nodes if sufficient capacity remains. If all worker MachineSets are scaled to "0", workloads may stop completely.
-
+> When you scale down a MachineSet, some workers will be drained and deleted. Workloads will automatically restart on remaining nodes if sufficient capacity remains. If all worker MachineSets are scaled to "0", workloads may stop completely.
 
 ### Default MachineSets available
 
 UKCloud offers three charging models for OpenShift workers:
-- Hourly - This is charged by the hour, with a 1 hour minimum charge.
-- Monthly - This is charged by the month, with a 1 month minimum charge. However, when used for the entire month, the cost is lower than running a hourly worker for the entire month.
-- Annual - This is charged by the year, with a 1 year minimum charge. However, when used for the entire year, the cost is lower than running a monthly worker for the entire year. If you would like annual MachineSets added to your cluster, please raise a Service Request via the My Calls section of the UKCloud Portal and provide us with the size, network connectivity of the MachineSets you'd like to add.
+
+- **Hourly** - This is charged by the hour, with a one hour minimum charge.
+
+- **Monthly** - This is charged by the month, with a one month minimum charge. However, when used for the entire month, the cost is lower than running a hourly worker for the entire month.
+
+- **Annual** - This is charged by the year, with a one year minimum charge. However, when used for the entire year, the cost is lower than running a monthly worker for the entire year. If you'd like to add annual MachineSets to your cluster, raise a Service Request via the My Calls section of the UKCloud Portal and provide us with the size and network connectivity of the MachineSets you'd like to add.
 
 Hourly MachineSets are particularly useful for short-term testing or for bursts of demand.
 
 By default, UKCloud OpenShift clusters have the following MachineSets available:
-- `<clusterid>-hourly-m1-medium` - 4 CPU, 16GB RAM - charged by the hour
-- `<clusterid>-monthly-m1-medium` - 4 CPU, 16GB RAM - charged by the month
-- `<clusterid>-hourly-r1-small` - 8 CPU, 16GB RAM - charged by the hour
-- `<clusterid>-monthly-r1-small` - 8 CPU, 16GB RAM - charged by the month
-- `<clusterid>-hourly-m1-large` - 4 CPU, 32B RAM - charged by the hour
-- `<clusterid>-monthly-m1-large` - 4 CPU, 32GB RAM - charged by the month
-- `<clusterid>-hourly-r1-medium` -  8 CPU, 32GB RAM - charged by the hour
-- `<clusterid>-monthly-r1-medium` - 8 CPU, 32GB RAM - charged by the month
 
-Costs for each flavour and charging model can be found in section 2.1.3 of the [UKCloud Pricing Guide](https://ukcloud.com/pricing-guide)
+- `<clusterid>-hourly-m1-medium` - 4 CPU, 16GB RAM, charged by the hour
+
+- `<clusterid>-monthly-m1-medium` - 4 CPU, 16GB RAM, charged by the month
+
+- `<clusterid>-hourly-r1-small` - 8 CPU, 16GB RAM, charged by the hour
+
+- `<clusterid>-monthly-r1-small` - 8 CPU, 16GB RAM, charged by the month
+
+- `<clusterid>-hourly-m1-large` - 4 CPU, 32B RAM, charged by the hour
+
+- `<clusterid>-monthly-m1-large` - 4 CPU, 32GB RAM, charged by the month
+
+- `<clusterid>-hourly-r1-medium` -  8 CPU, 32GB RAM, charged by the hour
+
+- `<clusterid>-monthly-r1-medium` - 8 CPU, 32GB RAM, charged by the month
+
+For information about costs for each flavour and charging model, see section 2.1.3 of the [UKCloud Pricing Guide](https://ukcloud.com/pricing-guide).
 
 > [!NOTE]
-> MachineSets for larger flavours of node can be added by UKCloud - raise a Service Request via the My Calls section of the UKCloud Portal and provide us with the size, network connectivity of the MachineSets you'd like to add.
-
-
+> UKCloud can add MachineSets for larger node flavours. If this is something you require, raise a Service Request via the My Calls section of the UKCloud Portal and provide us with the size and network connectivity of the MachineSets you'd like to add.
 
 ### Further information
 
 For more information, see the Red Hat OpenShift Documentation:
 https://docs.openshift.com/container-platform/4.8/machine_management/manually-scaling-machineset.html
-
 
 ## Feedback
 

--- a/articles/openshift/oshift-how-v4-scale.md
+++ b/articles/openshift/oshift-how-v4-scale.md
@@ -54,7 +54,7 @@ By default, UKCloud OpenShift clusters have the following MachineSets available:
 - `<clusterid>-monthly-r1-small` - 8 CPU, 16GB RAM - charged by the month
 - `<clusterid>-hourly-m1-large` - 4 CPU, 32B RAM - charged by the hour
 - `<clusterid>-monthly-m1-large` - 4 CPU, 32GB RAM - charged by the month
-- `<clusterid>-hourly-r1-medium` -  8 CPU, 32GB RAM - charged by the month
+- `<clusterid>-hourly-r1-medium` -  8 CPU, 32GB RAM - charged by the hour
 - `<clusterid>-monthly-r1-medium` - 8 CPU, 32GB RAM - charged by the month
 
 Costs for each flavour and charging model can be found in section 2.1.3 of the [UKCloud Pricing Guide](https://ukcloud.com/pricing-guide)

--- a/articles/openshift/oshift-ref-scaling.md
+++ b/articles/openshift/oshift-ref-scaling.md
@@ -41,7 +41,7 @@ If you'd like to scale up your cluster, raise a Service Request via the [My Call
 > The network connectivity you request for the scaled up nodes must be present in the cluster.
 
 > [!NOTE]
-> OpenShift v4 clusters support self-service scaling. You can find out more information in [*How to scale an OpenShift v4 cluster*](oshift-how-v4-scale.md).
+> OpenShift v4 clusters support self-service scaling. You can find out more information in [*How to scale an OpenShift v4 cluster*](oshift-how-scale-cluster-v4.md).
 
 ### Further information
 

--- a/articles/openshift/oshift-ref-scaling.md
+++ b/articles/openshift/oshift-ref-scaling.md
@@ -40,6 +40,9 @@ If you'd like to scale up your cluster, raise a Service Request via the [My Call
 > [!NOTE]
 > The network connectivity you request for the scaled up nodes must be present in the cluster.
 
+> [!NOTE]
+> OpenShift v4 clusters support self-service scaling. You can find out more information in [How To Scale OpenShift v4](oshift-how-v4-scale.md).
+
 ### Further information
 
 Below are some useful OpenShift documentation pages regarding scaling of a cluster:

--- a/articles/openshift/oshift-ref-scaling.md
+++ b/articles/openshift/oshift-ref-scaling.md
@@ -2,8 +2,8 @@
 title: Considerations when scaling an OpenShift cluster
 description: Provides information on things to consider when scaling a cluster
 services: openshift
-author: Kieran O'Neill
-reviewer: Andrew Garner
+author: koneill
+reviewer: agarner
 lastreviewed: 12/05/2021
 toc_rootlink: Reference
 toc_sub1: OpenShift v3.x
@@ -41,7 +41,7 @@ If you'd like to scale up your cluster, raise a Service Request via the [My Call
 > The network connectivity you request for the scaled up nodes must be present in the cluster.
 
 > [!NOTE]
-> OpenShift v4 clusters support self-service scaling. You can find out more information in [How To Scale OpenShift v4](oshift-how-v4-scale.md).
+> OpenShift v4 clusters support self-service scaling. You can find out more information in [*How to scale an OpenShift v4 cluster*](oshift-how-v4-scale.md).
 
 ### Further information
 


### PR DESCRIPTION
- Add `oshift-how-v4-scale.md` to summarise how to scale MachineSets in OpenShift v4
- Add a note to the v3 scaling reference guide to highlight that self-service scaling is possible in OpenShift v4
- Minor fix to `oshift-how-use-netpol-v4.md` to hopefully fix an issue in the live site where the v3 version is displayed instead