### PR TITLE
Update ptl-ref-user-access.md

### DIFF
--- a/articles/portal/ptl-ref-user-access.md
+++ b/articles/portal/ptl-ref-user-access.md
@@ -53,11 +53,7 @@ There are a number of Access Management activities which UKCloud can assist with
 
 ### Password reset
 
-In the event that you need to reset your password:
-
-- For the Assured OFFICIAL Portal, a self-service facility is available from the log on page. Alternatively your administrator can change your password.
-
-- For the Elevated OFFICIAL Portal, your password or memorable word will need to be changed by your administrator.
+In the event that you need to reset your password, a self-service facility is available from the log on page. Alternatively your administrator can change your password.
 
 UKCloud Support will advise you of the names of your administrators if required.
 


### PR DESCRIPTION
There's no longer a need to differentiate between the two portals - the forgotten password functionality is now the same for both.