### PR TITLE
Op 4680

### DIFF
--- a/articles/openstack/ostack-how-move-resources.md
+++ b/articles/openstack/ostack-how-move-resources.md
@@ -20,7 +20,7 @@ toc_mdlink: ostack-how-move-resources.md
 
 ## Overview
 
-This article provides examples of how to move OpenStack resources (for example, instance, images and volumes) between the different independent regions currently offered by UKCloud to help ensure the highest level of application resilience and availability.
+This article provides examples of how to move OpenStack resources (for example, instance images and volumes) between the different independent regions currently offered by UKCloud to help ensure the highest level of application resilience and availability.
 
 ### Intended audience
 
@@ -120,7 +120,7 @@ To achieve this across different regions, the use of a VPN may be required. Deta
 
           openstack volume list
 
-        If your source volume shows as being 'Attached to' in the resulting output then note the `ID` of your source volume and proceed to step 1b, otherwise note the `ID` of your source volume and proceed to step 2.
+        If your source volume shows as being `Attached to` in the resulting output then note the `ID` of your source volume and proceed to step 1b, otherwise note the `ID` of your source volume and proceed to step 2.
 
     b. To detach your source volume from an instance, enter the following command:
 

--- a/articles/openstack/ostack-how-move-resources.md
+++ b/articles/openstack/ostack-how-move-resources.md
@@ -20,11 +20,11 @@ toc_mdlink: ostack-how-move-resources.md
 
 ## Overview
 
-This article provides examples of how to move OpenStack resources (for example, instance images and volumes) between the different independent regions currently offered by UKCloud to help ensure the highest level of application resilience and availability.
+This article provides examples of how to move OpenStack resources (for example, instance, images and volumes) between the different independent regions currently offered by UKCloud to help ensure the highest level of application resilience and availability.
 
 ### Intended audience
 
-Anyone responsible for the design and implementation of applications and services deployed on UKCloud OpenStack service, and should be familiar with using the OpenStack dashboard and API/CLI.
+Anyone responsible for the design and implementation of applications and services deployed on UKCloud for OpenStack, and should be familiar with using the OpenStack dashboard and API/CLI.
 
 ## Background
 
@@ -42,8 +42,6 @@ The following table outlines the regions and zones that are currently available 
 
 Site | Region | Zone
 -----|--------|-----
-Corsham | 00005 (cor00005.cni.ukcloud.com) | 0000c-1
-&nbsp; | &nbsp; | 0000c-2
 Farnborough | 00006 (frn00006.cni.ukcloud.com) | 00021-1
 &nbsp; | &nbsp; | 00021-2
 Corsham 2 | 00005 (cor00005-2.cni.ukcloud.com) | 00026-1

--- a/articles/openstack/ostack-how-move-resources.md
+++ b/articles/openstack/ostack-how-move-resources.md
@@ -3,7 +3,7 @@ title: How to move resources between OpenStack regions
 description: Helps you understand how you can move resources between OpenStack regions
 services: openstack
 author: Sue Highmoor
-reviewer: rbeck
+reviewer: ribeck
 lastreviewed: 07/01/2022
 
 toc_rootlink: How To

--- a/articles/openstack/ostack-how-move-resources.md
+++ b/articles/openstack/ostack-how-move-resources.md
@@ -3,8 +3,8 @@ title: How to move resources between OpenStack regions
 description: Helps you understand how you can move resources between OpenStack regions
 services: openstack
 author: Sue Highmoor
-reviewer: bnicholls
-lastreviewed: 29/01/2021
+reviewer: rbeck
+lastreviewed: 07/01/2022
 
 toc_rootlink: How To
 toc_sub1:
@@ -65,9 +65,9 @@ The following provides a code example of how to achieve this export and import o
 
     Note the `ID` of your source instance as shown in the resulting output.
 
-2. To create the snapshot of the source instance, enter the following command:
+2. To create the image of the source instance, enter the following command:
 
-        openstack server image create --name <snapshot-name> <id-of-server>
+        openstack server image create --name <name-for-image> <id-of-server>
 
     Note the `id` shown in the resulting output.
 
@@ -79,7 +79,7 @@ The following provides a code example of how to achieve this export and import o
 
 4. To download source image snapshot, enter the following command:
 
-        openstack image save <id-of-image-to-download> --file <image-name> 
+        openstack image save <id-of-image-to-download> --file <output-location> 
 
     If the image size is greater than the memory of the local host, the following may be required:
        
@@ -120,21 +120,21 @@ To achieve this across different regions, the use of a VPN may be required. Deta
 
           openstack volume list
 
-        If your source volume shows as being Attached to in the resulting output then note the `ID` of your source volume and proceed to step 1b, otherwise note the `ID` of your source volume and proceed to step 2.
+        If your source volume shows as being 'Attached to' in the resulting output then note the `ID` of your source volume and proceed to step 1b, otherwise note the `ID` of your source volume and proceed to step 2.
 
     b. To detach your source volume from an instance, enter the following command:
 
-        openstack server remove volume \<server id\> \<volume id\>
+        openstack server remove volume <id-of-server> <id-of-volume>
 
     Double check the volume has been detached by running the command in step 1a.
 
 2. Upload the source volume to the OpenStack Glance image repository using the following command:
 
-        openstack image create --volume <volume id> <name>
+        openstack image create --volume <id-of-volume> <name-for-image>
 
 3. Download the source volume image to your local device using the following command:
 
-        openstack image save <id-of-image-to-download> --file <image-name> 
+        openstack image save <id-of-image-to-download> --file <output-location>
 
     If the image size is greater than the memory of the local host, the following may be required:
         
@@ -149,11 +149,11 @@ To achieve this across different regions, the use of a VPN may be required. Deta
 
     - Enter the following command:
 
-          openstack image create  --file <path-to-file-to-upload> --disk-format raw --container-format bare <name-for-upload>
+          openstack image create --file <path-to-file-to-upload> --disk-format raw --container-format bare <name-for-upload>
 
 5. To create a new volume in the target region based upon the original source volume, enter the following command:
 
-        openstack volume create --image <uploaded-image> --size <size-of-volume-to-create> --type <TIER1/TIER2> <Name>
+        openstack volume create --image <id-of-image> --size <size-of-volume-to-create> --type <TIER1/TIER2> <name-for-volume>
 
 ## Next steps
 


### PR DESCRIPTION
Removed reference to cor00005 site-region-zone.
Adding consistency across the naming conventions in the examples to make it easier to understand.