### PR TITLE
Ensuring responsibilities are clear

### DIFF
--- a/articles/managed-operations/man-sco-patching.md
+++ b/articles/managed-operations/man-sco-patching.md
@@ -97,9 +97,9 @@ Within 5 business days of accepting an order, UKCloud will enable the customer's
 
 Any elements within the [Scope of Patching as a Service](#scope-of-patching-as-a-service) section of this article where the customer is listed as Accountable or Responsible.
 
-Ensuring that patches are being applied properly, and to contact UKCloud support for assistance if they believe they are not.
+Ensuring that patches are being applied properly, and contacting UKCloud support for assistance if they believe they are not.
 
-Ensuring that all devices and their Operating Systems are in a healthy, patch-ready state.
+Ensuring that all devices and their operating systems are in a healthy, patch-ready state.
 
 The control and management of access and responsibilities for end users, including appropriate connectivity, security and accreditation if required. If access is required over government secure networks such as HSCN, Janet, RLI or PSN (including legacy networks), the customer is responsible for adhering to the Code of Connection.
 

--- a/articles/managed-operations/man-sco-patching.md
+++ b/articles/managed-operations/man-sco-patching.md
@@ -99,7 +99,7 @@ Any elements within the [Scope of Patching as a Service](#scope-of-patching-as-a
 
 Ensuring that patches are being applied properly, and to contact UKCloud support for assistance if they believe they are not.
 
-Ensuring that all devices and their Operating Systems are healthy and are in a patch-ready state.
+Ensuring that all devices and their Operating Systems are in a healthy, patch-ready state.
 
 The control and management of access and responsibilities for end users, including appropriate connectivity, security and accreditation if required. If access is required over government secure networks such as HSCN, Janet, RLI or PSN (including legacy networks), the customer is responsible for adhering to the Code of Connection.
 

--- a/articles/managed-operations/man-sco-patching.md
+++ b/articles/managed-operations/man-sco-patching.md
@@ -99,7 +99,7 @@ Any elements within the [Scope of Patching as a Service](#scope-of-patching-as-a
 
 Ensuring that patches are being applied properly, and to contact UKCloud support for assistance if they believe they are not.
 
-Ensuring that the all devices and OSes are healthy and are in a patch-ready state.
+Ensuring that all devices and their Operating Systems are healthy and are in a patch-ready state.
 
 The control and management of access and responsibilities for end users, including appropriate connectivity, security and accreditation if required. If access is required over government secure networks such as HSCN, Janet, RLI or PSN (including legacy networks), the customer is responsible for adhering to the Code of Connection.
 

--- a/articles/managed-operations/man-sco-patching.md
+++ b/articles/managed-operations/man-sco-patching.md
@@ -3,8 +3,8 @@ title: Patching as a Service Service Scope
 description: Outlines important details regarding Patching as a Service
 services: managed-operations
 author: sdixon
-reviewer: sdixon
-lastreviewed: 27/07/2021
+reviewer: mgough
+lastreviewed: 19/01/2021
 toc_rootlink: Managed IT Operations
 toc_sub1: Patching as a Service
 toc_sub2:
@@ -96,6 +96,10 @@ Within 5 business days of accepting an order, UKCloud will enable the customer's
 ## Customer responsibilities
 
 Any elements within the [Scope of Patching as a Service](#scope-of-patching-as-a-service) section of this article where the customer is listed as Accountable or Responsible.
+
+Ensuring that patches are being applied properly, and to contact UKCloud support for assistance if they believe they are not.
+
+Ensuring that the all devices and OSes are healthy and are in a patch-ready state.
 
 The control and management of access and responsibilities for end users, including appropriate connectivity, security and accreditation if required. If access is required over government secure networks such as HSCN, Janet, RLI or PSN (including legacy networks), the customer is responsible for adhering to the Code of Connection.
 


### PR DESCRIPTION
Asked SDixon to confirm he is happy with the addition of two lines that increase the verbosity of the expected responsibilities of a man patching consumer. This isn't a change to the scope as much as it's just laying it out better.