### PR TITLE
Add note to create VPG article

### DIFF
--- a/articles/vmware/vmw-faq-journaling-protection.md
+++ b/articles/vmware/vmw-faq-journaling-protection.md
@@ -155,6 +155,8 @@ Yes, it is included with the Journaling Protection option for use with the 2, 7,
 
 We recommend that you do not power off a VM if it's included in a protected vApp. Although powering off a VM may not immediately affect the protection of the vApp, if Zerto attempts to access the powered off VM, it could cause replication of all the VMs in the vApp to cease. If a powered-off VM causes an issue with vApp protection, Zerto will issue an alert.
 
+If you make configuration changes to a VM, for example to add or extend disks or change the networking, you should do this while the VM is powered on if possible. If you must power off the VM, after powering it back on check the VPG to make sure there are no errors.
+
 If you add a powered-off VM to a protected vApp, the VM will not be protected until you've powered it on and Zerto has performed the initial sync. In this case, the powered-off VM will not affect the protection of the vApp.
 
 ### Is Journaling Protection enabled in all regions?

--- a/articles/vmware/vmw-how-zerto-create-vpg.md
+++ b/articles/vmware/vmw-how-zerto-create-vpg.md
@@ -23,6 +23,11 @@ A virtual protection group (VPG) is a collection of virtual machines (VMs) that 
 
 After the initial synchronisation completes, any writes to disk from the VMs in the source site are sent to the target site. These writes are stored in the target site in journals.
 
+> [!NOTE]
+> We recommend that you do not power off a protected VM. If Zerto attempts to access the powered off VM, it could cause replication of all the VMs in the VPG to cease.
+>
+> If you make configuration changes to a VM, for example to add or extend disks or change the networking, you should do this while the VM is powered on if possible. If you must power off the VM, after powering it back on check the VPG to make sure there are no errors.
+
 ### Intended audience
 
 This guide is intended for users who are:


### PR DESCRIPTION
Add note to How to create a virtual protection group article to advise users against powering off protected VMs (or to check the VPG if powering off the VM is necessary).
Updated reviewed offline by SME.