### PR TITLE
fix broken link to G12 FAQ

### DIFF
--- a/articles/other/other-faq-ukcloud.md
+++ b/articles/other/other-faq-ukcloud.md
@@ -94,7 +94,6 @@ Patching as a Service           | [here](../managed-operations/man-faq-patching.
 Service                               | FAQ
 --------------------------------------|----
 Jumpstart                             | [here](../pro-services/ps-faq-jumpstart.md)
-G-Cloud 12 enhancements and additions | [here](other-faq-g12.md)
 Invoice and billing                   | [here](other-faq-billing.md)
 Service Level Agreement               | [here](other-faq-sla.md)
 MISO rebate                           | [here](other-faq-miso-rebate.md)


### PR DESCRIPTION
The G-Cloud 12 FAQ was retired, so need to remove link from the FAQ master list; no review required