### PR TITLE
Fix link for free trials

### DIFF
--- a/articles/other/other-sco-free-trials.md
+++ b/articles/other/other-sco-free-trials.md
@@ -79,7 +79,7 @@ Free trials are:
 
 Requesting a trial:
 
-- Request via UKCloud website: <https://www.ukcloud.com/free-trial-sign-up>, where you will need to accept the [trial terms and conditions](https://ukcloud.com/free-trial-terms-and-conditions/)
+- Request via UKCloud website: <https://ukcloud.com/free-trials/>, where you will need to accept the [trial terms and conditions](https://ukcloud.com/free-trial-terms-and-conditions/)
 
 - Your environment is set up
 


### PR DESCRIPTION
URL for Free Trials website page has changed. Pull request to fix the link in the related KC article.