### PR TITLE
Fix broken link to customer engagement factsheet

### DIFF
--- a/articles/azure/azs-sco.md
+++ b/articles/azure/azs-sco.md
@@ -279,7 +279,7 @@ UKCloud can offer additional professional and managed services in relation to Mi
 
 **Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance required during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Support Desk.** After the initial onboarding and design phase, customers can utilise the standard UKCloud support entitlement, which is documented in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial onboarding and design phase, customers can utilise the standard UKCloud support entitlement. For more information, see [*Raising and escalating support tickets with customer support*](../portal/ptl-ref-raise-escalate-service-request.md).
 
 ## Pricing and billing
 

--- a/articles/cdsz/cdsz-sco.md
+++ b/articles/cdsz/cdsz-sco.md
@@ -199,7 +199,7 @@ We provide you with monthly bills covering your monthly spend.
 
 **Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Support Desk.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [Customer Engagement Factsheet](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial onboarding and design phase, customers can utilise the standard UKCloud support entitlement. For more information, see [*Raising and escalating support tickets with customer support*](../portal/ptl-ref-raise-escalate-service-request.md).
 
 ## Customer responsibilities
 

--- a/articles/cloud-storage/cs-sco.md
+++ b/articles/cloud-storage/cs-sco.md
@@ -124,9 +124,7 @@ You can request a migration through a Service Request. Migrations may be between
 
 **Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Support Desk.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement.
-
-For more information about our award-winning customer service, see the [Customer Experience](https://ukcloud.com/ukcloud-support/customer-experience/) page on our website.
+**Support Desk.** After the initial onboarding and design phase, customers can utilise the standard UKCloud support entitlement. For more information, see [*Raising and escalating support tickets with customer support*](../portal/ptl-ref-raise-escalate-service-request.md).
 
 ## Customer responsibilities
 

--- a/articles/oracle/orcl-sco.md
+++ b/articles/oracle/orcl-sco.md
@@ -191,7 +191,7 @@ UKCloud do not currently provide migration services, however customers are free 
 
 **Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Support Desk.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial onboarding and design phase, customers can utilise the standard UKCloud support entitlement. For more information, see [*Raising and escalating support tickets with customer support*](../portal/ptl-ref-raise-escalate-service-request.md).
 
 ## Customer responsibilities
 

--- a/articles/sra/sra-sco.md
+++ b/articles/sra/sra-sco.md
@@ -206,7 +206,7 @@ We provide you with monthly bills covering your monthly spend.
 
 **Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Support Desk.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [Customer Engagement Factsheet](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial onboarding and design phase, customers can utilise the standard UKCloud support entitlement. For more information, see [*Raising and escalating support tickets with customer support*](../portal/ptl-ref-raise-escalate-service-request.md).
 
 ## Customer responsibilities
 

--- a/articles/vmware/vmw-sco-vls-ws1.md
+++ b/articles/vmware/vmw-sco-vls-ws1.md
@@ -130,9 +130,7 @@ Customers requiring additional licences should contact their Client Director or 
 
 **Service Delivery Manager (SDM).** An assigned point of contact who will provide customers with any assistance required during their use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Support Desk.** After the initial onboarding and design phase, customers can utilise the standard UKCloud support entitlement.
-
-For more information, see https://ukcloud.com/ukcloud-support/customer-experience/.
+**Support Desk.** After the initial onboarding and design phase, customers can utilise the standard UKCloud support entitlement. For more information, see [*Raising and escalating support tickets with customer support*](../portal/ptl-ref-raise-escalate-service-request.md).
 
 ## Technical support levels and ownership
 

--- a/articles/vmware/vmw-sco.md
+++ b/articles/vmware/vmw-sco.md
@@ -241,7 +241,7 @@ Customers are free to migrate their workloads. You can also request a migration 
 
 **Service Delivery Manager (SDM).** An assigned point of contact who will provide any assistance you require during your use of the service, including onboarding, service reviews and incident reporting and escalation.
 
-**Support Desk.** After the initial on-boarding and design phase, you can utilise the standard UKCloud support entitlement, which is documented in the [*Customer Engagement Factsheet*](https://ukcloud.com/wp-content/uploads/2018/08/ukcloud-factsheet-customer-care.pdf).
+**Support Desk.** After the initial onboarding and design phase, customers can utilise the standard UKCloud support entitlement. For more information, see [*Raising and escalating support tickets with customer support*](../portal/ptl-ref-raise-escalate-service-request.md).
 
 ## Customer responsibilities
 


### PR DESCRIPTION
The old customer engagement factsheet was removed from the website. This pull request removes links to the factsheet from KC articles.