### PR TITLE
Fix titles for VLS articles

### DIFF
--- a/articles/vmware/vmw-sco-vls-ws1.md
+++ b/articles/vmware/vmw-sco-vls-ws1.md
@@ -11,7 +11,7 @@ toc_sub1: VMware Licence Service
 toc_sub2:
 toc_sub3:
 toc_sub4:
-toc_title: Service Scope
+toc_title: UKCloud VMware Workspace ONE VLS Service Scope
 toc_fullpath: Service Information/VMware Licence Service/vmw-sco-vls-ws1.md
 toc_mdlink: vmw-sco-vls-ws1.md
 ---

--- a/articles/vmware/vmw-sco-vls.md
+++ b/articles/vmware/vmw-sco-vls.md
@@ -11,7 +11,7 @@ toc_sub1: VMware Licence Service
 toc_sub2:
 toc_sub3:
 toc_sub4:
-toc_title: Service Scope
+toc_title: VMware Licence Service (VLS) Service Scope
 toc_fullpath: Service Information/VMware Licence Service/vmw-sco-vls.md
 toc_mdlink: vmw-sco-vls.md
 ---

--- a/articles/vmware/vmw-sd-vls.md
+++ b/articles/vmware/vmw-sd-vls.md
@@ -10,7 +10,7 @@ toc_sub1: VMware Licence Service
 toc_sub2:
 toc_sub3:
 toc_sub4:
-toc_title: Service Definition
+toc_title: VMware Licence Service (VLS) Service Definition
 toc_fullpath: Service Information/VMware Licence Service/vmw-sd-vls.md
 toc_mdlink: vmw-sd-vls.md
 ---


### PR DESCRIPTION
The TOC titles for the two VLS service scopes need updating to make it clear which service scope is for which service