### PR TITLE
Update customer service targets for P1 incidents

### DIFF
--- a/articles/portal/ptl-ref-raise-escalate-service-request.md
+++ b/articles/portal/ptl-ref-raise-escalate-service-request.md
@@ -107,7 +107,7 @@ Your experience is important to us. We measure our performance against service t
 
 Ticket priority | Initial response target | Resolution target
 ----------------|-------------------------|------------------
-**P1 incident** | 15 minutes | 90% in 12 hours
+**P1 incident** | 15 minutes | 90% in 4 hours
 **P2 incident** | 1 hour | 90% in 24 hours
 **P3 incident** | 1 hour | 90% in 5 days
 **P4 incident** | 1 hour | 90% in 5 days


### PR DESCRIPTION
Update Raising and escalating support tickets article to reflect new customer service target for P1 incidents (changed from 90% in 12 hours to 90% in 4 hours)
Do not merge until 30th September