### PR TITLE
Update references to VCD API version

### DIFF
--- a/articles/other/other-ref-knowledge-guidelines.md
+++ b/articles/other/other-ref-knowledge-guidelines.md
@@ -350,7 +350,7 @@ Element | Convention | Example
 --------|------------|--------
 All interactive UI elements (including tabs) | Use **bold** | Select the **Enable** check box.<br>From the **File** menu, select **Open**.<br>On the **VMs** tab, ...
 All non-interactive UI elements (for example, windows, pages, dialog boxes, sections on a page) | Use *italics* | On the *User account* page, ...<br>In the *Create new user* dialog box, ...<br>In the *Contact details* section of the *Create new user* dialog box, ...
-Commands, code, parameters, user-entered text | Use `monospace` | Use the `slmgr` command to ...<br>`application/*+xml;version=34.0`<br>In the **Name** field, enter `Accept`.
+Commands, code, parameters, user-entered text | Use `monospace` | Use the `slmgr` command to ...<br>`application/json;version=36.2`<br>In the **Name** field, enter `Accept`.
 
 ## Related articles
 

--- a/articles/vmware/vmw-how-interact-vcd-api-powershell.md
+++ b/articles/vmware/vmw-how-interact-vcd-api-powershell.md
@@ -21,9 +21,9 @@ toc_mdlink: vmw-how-interact-vcd-api-powershell.md
 
 ### Useful Links
 
-You can find the schema reference for version 34.0 of the Cloud Director API here:
+You can find the schema reference for version 36.2 of the Cloud Director API here:
 
-<https://code.vmware.com/apis/912/vmware-cloud-director>
+<https://developer.vmware.com/apis/1232/vmware-cloud-director>
 
 ### PowerShell
 
@@ -64,7 +64,7 @@ For more detailed instructions, see [*How to access VMware Cloud Director throug
 
    $Global:Authorization = ""
 
-   $Global:Accept = "application/*+xml;version=34.0"
+   $Global:Accept = "application/json;version=36.2"
 
    $Global:xvCloudAuthorization = ""
 
@@ -140,7 +140,7 @@ For more detailed instructions, see [*How to access VMware Cloud Director throug
 
    Authorization = ""
 
-   Accept = "application/*+xml;version=34.0"
+   Accept = "application/json;version=36.2"
 
    xvCloudAuthorization = ""
 

--- a/articles/vmware/vmw-how-ps-export-edge-data.md
+++ b/articles/vmware/vmw-how-ps-export-edge-data.md
@@ -38,7 +38,7 @@ If you want to export your edge gateway configuration data (firewall rules, NAT 
        
        $webclient.Headers.Add("x-vcloud-authorization",$EdgeView.Client.SessionKey)
        
-       $webclient.Headers.Add("accept","application/*+xml;version=34.0")
+       $webclient.Headers.Add("accept","application/json;version=36.2")
        
        $edgeview.id -match "(?<=urn:vcloud:gateway:).*"
        

--- a/articles/vmware/vmw-how-retrieve-utilisation-metrics.md
+++ b/articles/vmware/vmw-how-retrieve-utilisation-metrics.md
@@ -113,7 +113,7 @@ You can retrieve current utilisation metrics for VMs in all regions.
 ## Curl example
 
 ```none
-curl -i -XGET -H 'Accept: application/*+xml;version=34.0' -H 'x-vcloud-authorization: 1234567890abcdef1234567890abcdef' https://vcd.portal.skyscapecloud.com/api/vApp/vm-12345678-aaaa-bbbb-cccc-1234567890ab/metrics/current
+curl -i -XGET -H 'Accept: application/json;version=36.2' -H 'x-vcloud-authorization: 1234567890abcdef1234567890abcdef' https://vcd.portal.skyscapecloud.com/api/vApp/vm-12345678-aaaa-bbbb-cccc-1234567890ab/metrics/current
 ```
 
 ## Retrieving historic utilisation metrics
@@ -255,7 +255,7 @@ You can retrieve historic utilisation metrics for VMs in all regions.
 ## Curl example
 
 ```none
-curl -i -XGET -H 'Accept: application/*+xml;version=34.0' -H 'x-vcloud-authorization: 1234567890abcdef1234567890abcdef' https://vcd.pod0000b.sys00005.portal.skyscapecloud.com/api/vApp/vm-12345678-aaaa-bbbb-cccc-1234567890ab/metrics/historic
+curl -i -XGET -H 'Accept: application/json;version=36.2' -H 'x-vcloud-authorization: 1234567890abcdef1234567890abcdef' https://vcd.pod0000b.sys00005.portal.skyscapecloud.com/api/vApp/vm-12345678-aaaa-bbbb-cccc-1234567890ab/metrics/historic
 ```
 
 ## Feedback


### PR DESCRIPTION
Latest supported API version is 36.2, so updating examples to refer to this version